### PR TITLE
Match group id for domain www.oras.land

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,20 @@ OCI Registry as Storage enables libraries to push OCI Artifacts to [OCI Conforma
 
 ## Consuming SDK
 
-SNAPSHOT version are published on GitHub Maven package.
+SNAPSHOT version are published on GitHub Maven packages.
+Releases are published on Maven Central
 
 Javadoc is published from main branch into: https://oras-project.github.io/oras-java/
+
+```xml
+<dependency>
+    <groupId>land.oras</groupId>
+    <artifactId>oras-java-sdk</artifactId>
+    <version>VERSION_HERE</version>
+</dependency>
+```
+
+### Only for SNAPSHOTS (only for testing)
 
 GitHub requires authentication to download packages. You can use a personal access token to authenticate with GitHub Packages. To authenticate with GitHub Packages, you need to update your `~/.m2/settings.xml` file to include your personal access token.
 
@@ -79,19 +90,13 @@ Registry registry = Registry.Builder.builder().insecure().build();
 registry.pullArtifact(ContainerRef.parse("localhost:5000/hello:v1"), Path.of("folder"));
 ```
 
-### Deploy to GitHub Packages
+### Deploy SNAPSHOTS
 
-This is temporary until published to Maven Central with a proper workflow.
-
-The maven resolver must be switched to `wagon` to deploy to GitHub Packages.
-
-```shell
-mvn -Dmaven.resolver.transport=wagon -DskipTests -Poras-java clean deploy
-```
+SNAPSHOTS are automatically deployed when the `main` branch is updated. See the [GitHub Actions](.github/workflows/deploy-snapshots.yml) for more details.
 
 ### Perform release
 
-- Ensure the draft release version correspond to the version on the `pom.xml`
+- Ensure the draft release version correspond to the version on the `pom.xml`. Specially if changing the major or minor version. Patch releases are automatically updated.
 - Run the release workflow
 
 ## Code of Conduct

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>land.oras</groupId>
   <artifactId>oras-java-sdk</artifactId>
-  <version>0.1.10-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>ORAS Java SDK</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>land.oras.java</groupId>
+  <groupId>land.oras</groupId>
   <artifactId>oras-java-sdk</artifactId>
   <version>0.1.10-SNAPSHOT</version>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -538,12 +538,10 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
           </plugin>
-          <!--
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
           </plugin>
-          -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
### Description

- Release workflow is ready to be used (artifacts signed, plugin added etc...)
- I think publishing to "land.oras" is enough. Since the artifact id is already `oras-java-sdk`
- This should finalize the maven central publication. The last step is the domain verification
- I would like also oras owner have access to this namespace
- This require domain validation via DNS https://central.sonatype.org/register/namespace/#for-dns Basically a domain admin must registrer a TXT record. Then we can hit "Verify" domain

![verification](https://github.com/user-attachments/assets/9b14ab5c-e6d7-4c1a-ad34-3c48c6dfa4bf)

![deployment_info](https://github.com/user-attachments/assets/b464d85c-6a8f-4983-bead-bc7ec894c12f)

[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [ ] The description of this pull request is detailed and explain why this pull request is needed
- [ ] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.

