### PR TITLE
Podman/buildhah auth

### DIFF
--- a/src/test/java/land/oras/RegistryWireMockTest.java
+++ b/src/test/java/land/oras/RegistryWireMockTest.java
@@ -123,7 +123,7 @@ public class RegistryWireMockTest {
 
         ContainerRef containerRef = ContainerRef.forRegistry("localhost:%d".formatted(wmRuntimeInfo.getHttpPort()));
         FileStoreAuthenticationProvider authProvider =
-                new FileStoreAuthenticationProvider(FileStore.newFileStore(configDir.resolve("config.json")));
+                new FileStoreAuthenticationProvider(FileStore.newFileStore(List.of(configDir.resolve("config.json"))));
 
         // Return data from wiremock
         WireMock wireMock = wmRuntimeInfo.getWireMock();

--- a/src/test/java/land/oras/credentials/FileStoreTest.java
+++ b/src/test/java/land/oras/credentials/FileStoreTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import land.oras.ContainerRef;
 import land.oras.exception.OrasException;
 import land.oras.utils.Const;
@@ -220,7 +221,7 @@ class FileStoreTest {
                 FileStore.ConfigFile.fromCredential(new FileStore.Credential("admin", "password123"));
 
         // Load the configuration from the temporary file
-        FileStore.Config.load(configFile);
+        FileStore.Config.load(List.of(configFile));
 
         assertEquals("docker.io", containerRef.getRegistry());
         assertEquals("library/foo", containerRef.getNamespace());


### PR DESCRIPTION
### Description

See https://github.com/oras-project/oras-go/issues/836
https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md#format

Use single hostname for now. 

Future PR can include better matching for namespace. Since that now we pass the ContainerRef we should be able to propagate the most accurate auth depening on the endpoint.

### Testing done

mvn clean install

Tested by removing rm ~/.docker/config.json and ensure it's using 

```
Loaded auth config file: /run/user/1002/containers/auth.json
```

### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.

