### PR TITLE
Use setup java action for package detection

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -14,6 +14,13 @@ jobs:
       id-token: write
       packages: write
     steps:
+
+      - name: Setup Java Action
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
       - name: Setup Maven Action
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:


### PR DESCRIPTION
Sadly openssf doesn't detect such workflow as release workflow

Since it require 

```go
{
	Uses: "actions/setup-java",
},
{
	Run: "mvn.*deploy",
},
```

Not ideal but I least would increase the score

### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
