### PR TITLE
Add support for SHA-512 hash

### DIFF
--- a/src/main/java/land/oras/ContainerRef.java
+++ b/src/main/java/land/oras/ContainerRef.java
@@ -24,6 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import land.oras.exception.OrasException;
 import land.oras.utils.Const;
+import land.oras.utils.SupportedAlgorithm;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -136,6 +137,19 @@ public final class ContainerRef {
     }
 
     /**
+     * Get the algorithm for this container ref
+     * @return The algorithm
+     */
+    public SupportedAlgorithm getAlgorithm() {
+        // Default if not set
+        if (digest == null) {
+            return SupportedAlgorithm.getDefault();
+        }
+        // See https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
+        return SupportedAlgorithm.fromPrefix(digest.split(":")[0]);
+    }
+
+    /**
      * Get the API prefix
      * @return The API prefix
      */
@@ -226,6 +240,15 @@ public final class ContainerRef {
         if (namespace != null) {
             namespace = namespace.substring(0, namespace.length() - 1);
         }
+
+        // Validate digest algorithm
+        if (digest != null) {
+            String prefix = digest.split(":")[0];
+            if (!SupportedAlgorithm.isSupported(prefix)) {
+                throw new OrasException("Unsupported digest algorithm: " + prefix);
+            }
+        }
+
         return new ContainerRef(registry, namespace, repository, tag, digest);
     }
 

--- a/src/main/java/land/oras/Layer.java
+++ b/src/main/java/land/oras/Layer.java
@@ -28,8 +28,8 @@ import java.util.Collections;
 import java.util.Map;
 import land.oras.exception.OrasException;
 import land.oras.utils.Const;
-import land.oras.utils.DigestUtils;
 import land.oras.utils.JsonUtils;
+import land.oras.utils.SupportedAlgorithm;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -219,7 +219,7 @@ public final class Layer {
                 Map.of(Const.ANNOTATION_TITLE, file.getFileName().toString());
         return new Layer(
                 Const.DEFAULT_BLOB_MEDIA_TYPE,
-                DigestUtils.sha256(file),
+                SupportedAlgorithm.getDefault().digest(file),
                 file.toFile().length(),
                 file,
                 annotations);
@@ -227,13 +227,14 @@ public final class Layer {
 
     /**
      * Create a layer from data
+     * @param containerRef The container reference
      * @param data The data
      * @return The layer
      */
-    public static Layer fromData(byte[] data) {
+    public static Layer fromData(ContainerRef containerRef, byte[] data) {
         return new Layer(
                 Const.DEFAULT_BLOB_MEDIA_TYPE,
-                DigestUtils.sha256(data),
+                containerRef.getAlgorithm().digest(data),
                 data.length,
                 Base64.getEncoder().encodeToString(data),
                 Map.of());

--- a/src/main/java/land/oras/utils/DigestUtils.java
+++ b/src/main/java/land/oras/utils/DigestUtils.java
@@ -40,33 +40,6 @@ public final class DigestUtils {
     private DigestUtils() {}
 
     /**
-     * Calculate the sha256 digest of a byte array
-     * @param bytes The bytes
-     * @return The digest
-     */
-    public static String sha256(byte[] bytes) {
-        return digest("SHA-256", bytes);
-    }
-
-    /**
-     * Calculate the sha256 digest of a file
-     * @param file The file
-     * @return The digest
-     */
-    public static String sha256(Path file) {
-        return digest("SHA-256", file);
-    }
-
-    /**
-     * Calculate the sha256 digest of a file
-     * @param inputStream The input stream
-     * @return The digest
-     */
-    public static String sha256(InputStream inputStream) {
-        return digest("SHA-256", inputStream);
-    }
-
-    /**
      * Calculate the digest of a file
      * @param algorithm The algorithm
      * @param path The path
@@ -135,9 +108,26 @@ public final class DigestUtils {
             for (byte b : hashBytes) {
                 sb.append(String.format("%02x", b));
             }
-            return "sha256:%s".formatted(sb.toString());
+            return "%s:%s".formatted(algorithm.toLowerCase().replaceAll("-", ""), sb.toString());
         } catch (Exception e) {
             throw new OrasException("Failed to calculate digest", e);
         }
+    }
+
+    /**
+     * Bytes to hex string
+     * @param bytes of bytes[]
+     * @return hex string
+     */
+    public static String bytesToHex(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
     }
 }

--- a/src/main/java/land/oras/utils/SupportedAlgorithm.java
+++ b/src/main/java/land/oras/utils/SupportedAlgorithm.java
@@ -1,0 +1,144 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2025 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.utils;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import land.oras.exception.OrasException;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Supported algorithms for digest.
+ * See @link <a href="https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests">https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests</a>
+ * See @link <a href="https://github.com/opencontainers/image-spec/blob/main/descriptor.md#registered-algorithms">https://github.com/opencontainers/image-spec/blob/main/descriptor.md#registered-algorithms</a>
+ */
+@NullMarked
+public enum SupportedAlgorithm {
+
+    /**
+     * SHA-256
+     */
+    SHA256("SHA-256", "sha256"),
+
+    /**
+     * SHA-512
+     */
+    SHA512("SHA-512", "sha512");
+
+    /**
+     * The algorithm
+     */
+    private final String algorithm;
+
+    /**
+     * The prefix
+     */
+    private final String prefix;
+
+    /**
+     * Get the algorithm
+     * @param algorithm The algorithm
+     * @param prefix The prefix
+     */
+    SupportedAlgorithm(String algorithm, String prefix) {
+        this.algorithm = algorithm;
+        this.prefix = prefix;
+    }
+
+    /**
+     * Get the algorithm
+     * @return The algorithm
+     */
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    /**
+     * Get the prefix
+     * @return The prefix
+     */
+    public String getPrefix() {
+        return prefix;
+    }
+
+    /**
+     * Digest a byte array
+     * @param bytes The bytes
+     * @return The digest
+     */
+    public String digest(byte[] bytes) {
+        return DigestUtils.digest(algorithm, bytes);
+    }
+
+    /**
+     * Digest a file
+     * @param file The file
+     * @return The digest
+     */
+    public String digest(Path file) {
+        return DigestUtils.digest(algorithm, file);
+    }
+
+    /**
+     * Digest an input stream
+     * @param inputStream The input stream
+     * @return The digest
+     */
+    public String digest(InputStream inputStream) {
+        return DigestUtils.digest(algorithm, inputStream);
+    }
+
+    /**
+     * Check if the algorithm is supported
+     * @param prefix The algorithm prefix
+     * @return True if supported
+     */
+    public static boolean isSupported(String prefix) {
+        for (SupportedAlgorithm supportedAlgorithm : SupportedAlgorithm.values()) {
+            if (supportedAlgorithm.getPrefix().equals(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the algorithm from a prefix
+     * @param prefix The prefix
+     * @return The algorithm
+     */
+    public static SupportedAlgorithm fromPrefix(String prefix) {
+        for (SupportedAlgorithm algorithm : SupportedAlgorithm.values()) {
+            if (algorithm.getPrefix().equals(prefix.toLowerCase())) {
+                return algorithm;
+            }
+        }
+        throw new OrasException("Unsupported algorithm: " + prefix);
+    }
+
+    /**
+     * Get the default algorithm
+     * @return The default algorithm
+     */
+    public static SupportedAlgorithm getDefault() {
+        return SupportedAlgorithm.SHA256;
+    }
+}

--- a/src/test/java/land/oras/ContainerRefTest.java
+++ b/src/test/java/land/oras/ContainerRefTest.java
@@ -20,9 +20,10 @@
 
 package land.oras;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
+import land.oras.exception.OrasException;
+import land.oras.utils.SupportedAlgorithm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -38,7 +39,16 @@ public class ContainerRefTest {
         assertEquals("library/foo", containerRef.getNamespace());
         assertEquals("hello-world", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());
+        assertEquals(SupportedAlgorithm.SHA256, containerRef.getAlgorithm());
         assertEquals("sha256:1234567890abcdef", containerRef.getDigest());
+    }
+
+    @Test
+    void shouldFailWithUnSupportedAlgorithm() {
+        assertThrows(
+                OrasException.class,
+                () -> ContainerRef.parse("docker.io/library/foo/hello-world:latest@test:1234567890abcdef"),
+                "Unsupported algorithm: test");
     }
 
     @Test

--- a/src/test/java/land/oras/utils/DigestUtilsTest.java
+++ b/src/test/java/land/oras/utils/DigestUtilsTest.java
@@ -40,14 +40,14 @@ public class DigestUtilsTest {
     private Path blobDir;
 
     @Test
-    void testByteArray() {
+    void testSha256ByteArray() {
         assertEquals(
                 "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-                DigestUtils.sha256("hello".getBytes()));
+                DigestUtils.digest("SHA-256", "hello".getBytes()));
     }
 
     @Test
-    void testFile() throws IOException {
+    void testSha256File() throws IOException {
         Files.createFile(blobDir.resolve("hello.txt"));
         Files.writeString(blobDir.resolve("hello.txt"), "hello");
         assertEquals(
@@ -56,7 +56,7 @@ public class DigestUtilsTest {
     }
 
     @Test
-    void testStream() throws IOException {
+    void testSha256Stream() throws IOException {
         Files.createFile(blobDir.resolve("hello.txt"));
         Files.writeString(blobDir.resolve("hello.txt"), "hello");
         try (var stream = Files.newInputStream(blobDir.resolve("hello.txt"))) {
@@ -67,11 +67,47 @@ public class DigestUtilsTest {
     }
 
     @Test
-    void testLargeFile() throws IOException {
+    void testSha256LargeFile() throws IOException {
         Files.createFile(blobDir.resolve("large.txt"));
         Files.writeString(blobDir.resolve("large.txt"), "a".repeat(1000000));
         assertEquals(
                 "sha256:cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
                 DigestUtils.digest("SHA-256", blobDir.resolve("large.txt")));
+    }
+
+    @Test
+    void testSha512ByteArray() {
+        assertEquals(
+                "sha512:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+                DigestUtils.digest("SHA-512", "hello".getBytes()));
+    }
+
+    @Test
+    void testSha512File() throws IOException {
+        Files.createFile(blobDir.resolve("hello.txt"));
+        Files.writeString(blobDir.resolve("hello.txt"), "hello");
+        assertEquals(
+                "sha512:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+                DigestUtils.digest("SHA-512", blobDir.resolve("hello.txt")));
+    }
+
+    @Test
+    void testSha512Stream() throws IOException {
+        Files.createFile(blobDir.resolve("hello.txt"));
+        Files.writeString(blobDir.resolve("hello.txt"), "hello");
+        try (var stream = Files.newInputStream(blobDir.resolve("hello.txt"))) {
+            assertEquals(
+                    "sha512:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+                    DigestUtils.digest("SHA-512", stream));
+        }
+    }
+
+    @Test
+    void testSha512LargeFile() throws IOException {
+        Files.createFile(blobDir.resolve("large.txt"));
+        Files.writeString(blobDir.resolve("large.txt"), "a".repeat(1000000));
+        assertEquals(
+                "sha512:e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b",
+                DigestUtils.digest("SHA-512", blobDir.resolve("large.txt")));
     }
 }


### PR DESCRIPTION
Default is still SHA-256 but do not fail when SHA-512 is used

### Description

Default is still SHA-256 but do not fail when SHA-512 is used

### Testing done

CI

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
