### PR TITLE
Replace docker.io by registry-1.docker.io when doing api calls

### DIFF
--- a/src/main/java/land/oras/ContainerRef.java
+++ b/src/main/java/land/oras/ContainerRef.java
@@ -98,6 +98,18 @@ public final class ContainerRef {
     }
 
     /**
+     * Get the API registry
+     * @return The API registry
+     */
+    public String getApiRegistry() {
+        String registry = getRegistry();
+        if (registry.equals("docker.io")) {
+            return "registry-1.docker.io";
+        }
+        return registry;
+    }
+
+    /**
      * Get the namespace
      * @return The namespace
      */

--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -459,8 +459,8 @@ public final class Registry {
                 LOG.debug(
                         "Copied layer {} from {} to {}",
                         newLayer.getDigest(),
-                        sourceContainer.getRegistry(),
-                        targetContainer.getRegistry());
+                        sourceContainer.getApiRegistry(),
+                        targetContainer.getApiRegistry());
             } catch (IOException e) {
                 throw new OrasException("Failed to copy artifact", e);
             }
@@ -565,7 +565,7 @@ public final class Registry {
             // Ensure location is absolute URI
             if (!location.startsWith("http") && !location.startsWith("https")) {
                 location = "%s://%s/%s"
-                        .formatted(getScheme(), containerRef.getRegistry(), location.replaceFirst("^/", ""));
+                        .formatted(getScheme(), containerRef.getApiRegistry(), location.replaceFirst("^/", ""));
             }
             LOG.debug("Location header: {}", location);
             response = client.upload(
@@ -633,7 +633,7 @@ public final class Registry {
             // Ensure location is absolute URI
             if (!location.startsWith("http") && !location.startsWith("https")) {
                 location = "%s://%s/%s"
-                        .formatted(getScheme(), containerRef.getRegistry(), location.replaceFirst("^/", ""));
+                        .formatted(getScheme(), containerRef.getApiRegistry(), location.replaceFirst("^/", ""));
             }
             LOG.debug("Location header: {}", location);
             response = client.put(
@@ -739,7 +739,7 @@ public final class Registry {
         String size = response.headers().get(Const.CONTENT_LENGTH_HEADER.toLowerCase());
         String digest = response.headers().get(Const.DOCKER_CONTENT_DIGEST_HEADER.toLowerCase());
         return JsonUtils.fromJson(response.response(), Manifest.class)
-                .withDescriptor(ManifestDescriptor.of(contentType, digest, Long.parseLong(size)));
+                .withDescriptor(ManifestDescriptor.of(contentType, digest, size == null ? 0 : Long.parseLong(size)));
     }
 
     /**

--- a/src/test/java/land/oras/ContainerRefTest.java
+++ b/src/test/java/land/oras/ContainerRefTest.java
@@ -36,6 +36,7 @@ public class ContainerRefTest {
         ContainerRef containerRef =
                 ContainerRef.parse("docker.io/library/foo/hello-world:latest@sha256:1234567890abcdef");
         assertEquals("docker.io", containerRef.getRegistry());
+        assertEquals("registry-1.docker.io", containerRef.getApiRegistry());
         assertEquals("library/foo", containerRef.getNamespace());
         assertEquals("hello-world", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());
@@ -85,6 +86,7 @@ public class ContainerRefTest {
     void shouldParseImageWithNoRegistry() {
         ContainerRef containerRef = ContainerRef.parse("hello-world:latest");
         assertEquals("docker.io", containerRef.getRegistry());
+        assertEquals("registry-1.docker.io", containerRef.getApiRegistry());
         assertNull(containerRef.getNamespace());
         assertEquals("hello-world", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());


### PR DESCRIPTION
### Description

Should fix https://github.com/oras-project/oras-java/issues/177

Similar to https://github.com/oras-project/oras-py/blob/1790ad7df3c83884f24aabd2ab4b2d97e4c2f3b0/oras/defaults.py#L10-L15 and https://github.com/oras-project/oras-go/blob/d92df9df65805259b6f3b8114d9dc939d71f5264/registry/reference_test.go#L235-L249

### Testing done

CI only

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
