### PR TITLE
Use library namespace by default for docker.io images

### DIFF
--- a/src/main/java/land/oras/Annotations.java
+++ b/src/main/java/land/oras/Annotations.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import land.oras.utils.JsonUtils;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Record for annotations
@@ -44,7 +45,10 @@ public record Annotations(
      * @param manifestAnnotations The manifest annotations
      * @return The annotations
      */
-    public static Annotations ofManifest(Map<String, String> manifestAnnotations) {
+    public static Annotations ofManifest(@Nullable Map<String, String> manifestAnnotations) {
+        if (manifestAnnotations == null) {
+            return empty();
+        }
         return new Annotations(new HashMap<>(), manifestAnnotations, new HashMap<>());
     }
 

--- a/src/main/java/land/oras/ContainerRef.java
+++ b/src/main/java/land/oras/ContainerRef.java
@@ -114,6 +114,10 @@ public final class ContainerRef {
      * @return The namespace
      */
     public @Nullable String getNamespace() {
+        String registry = getRegistry();
+        if (namespace == null && registry.equals("docker.io")) {
+            return "library";
+        }
         return namespace;
     }
 
@@ -147,7 +151,7 @@ public final class ContainerRef {
      * @return The new container reference
      */
     public ContainerRef withDigest(String digest) {
-        return new ContainerRef(registry, namespace, repository, tag, digest);
+        return new ContainerRef(registry, getNamespace(), repository, tag, digest);
     }
 
     /**
@@ -169,9 +173,9 @@ public final class ContainerRef {
      */
     private String getApiPrefix() {
         if (namespace != null) {
-            return "%s/v2/%s/%s".formatted(registry, namespace, repository);
+            return "%s/v2/%s/%s".formatted(getApiRegistry(), getNamespace(), repository);
         }
-        return "%s/v2/%s".formatted(registry, repository);
+        return "%s/v2/%s".formatted(getApiRegistry(), repository);
     }
 
     /**

--- a/src/main/java/land/oras/Manifest.java
+++ b/src/main/java/land/oras/Manifest.java
@@ -46,7 +46,7 @@ public final class Manifest {
     /**
      * The manifest descriptor
      */
-    private transient ManifestDescriptor descriptor;
+    private final transient ManifestDescriptor descriptor;
 
     private Manifest(
             int schemaVersion,
@@ -127,7 +127,7 @@ public final class Manifest {
      * @return The layers
      */
     public List<Layer> getLayers() {
-        return Collections.unmodifiableList(layers);
+        return layers != null ? Collections.unmodifiableList(layers) : List.of();
     }
 
     /**

--- a/src/test/java/land/oras/AnnotationsTest.java
+++ b/src/test/java/land/oras/AnnotationsTest.java
@@ -44,6 +44,14 @@ public class AnnotationsTest {
     }
 
     @Test
+    public void nullAnnotations() {
+        Annotations annotations = Annotations.ofManifest(null);
+        assertEquals(0, annotations.configAnnotations().size());
+        assertEquals(0, annotations.manifestAnnotations().size());
+        assertEquals(0, annotations.filesAnnotations().size());
+    }
+
+    @Test
     public void toJson() {
         Annotations annotations = new Annotations(
                 Map.of("hello", "world"), Map.of("foo", "bar"), Map.of("cake.txt", Map.of("fun", "more cream")));

--- a/src/test/java/land/oras/ContainerRefTest.java
+++ b/src/test/java/land/oras/ContainerRefTest.java
@@ -33,12 +33,11 @@ public class ContainerRefTest {
 
     @Test
     void shouldParseImageWithAllParts() {
-        ContainerRef containerRef =
-                ContainerRef.parse("docker.io/library/foo/hello-world:latest@sha256:1234567890abcdef");
+        ContainerRef containerRef = ContainerRef.parse("docker.io/library/foo/alpine:latest@sha256:1234567890abcdef");
         assertEquals("docker.io", containerRef.getRegistry());
         assertEquals("registry-1.docker.io", containerRef.getApiRegistry());
         assertEquals("library/foo", containerRef.getNamespace());
-        assertEquals("hello-world", containerRef.getRepository());
+        assertEquals("alpine", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());
         assertEquals(SupportedAlgorithm.SHA256, containerRef.getAlgorithm());
         assertEquals("sha256:1234567890abcdef", containerRef.getDigest());
@@ -48,66 +47,97 @@ public class ContainerRefTest {
     void shouldFailWithUnSupportedAlgorithm() {
         assertThrows(
                 OrasException.class,
-                () -> ContainerRef.parse("docker.io/library/foo/hello-world:latest@test:1234567890abcdef"),
+                () -> ContainerRef.parse("docker.io/library/foo/alpine:latest@test:1234567890abcdef"),
                 "Unsupported algorithm: test");
     }
 
     @Test
     void shouldParseImageWithNoNamespace() {
-        ContainerRef containerRef = ContainerRef.parse("docker.io/hello-world:latest@sha256:1234567890abcdef");
+        ContainerRef containerRef = ContainerRef.parse("docker.io/alpine:latest@sha256:1234567890abcdef");
         assertEquals("docker.io", containerRef.getRegistry());
+        assertEquals("library", containerRef.getNamespace());
+        assertEquals("alpine", containerRef.getRepository());
+        assertEquals("latest", containerRef.getTag());
+        assertEquals("sha256:1234567890abcdef", containerRef.getDigest());
+
+        containerRef = ContainerRef.parse("demo.goharbor.com/alpine:latest@sha256:1234567890abcdef");
+        assertEquals("demo.goharbor.com", containerRef.getRegistry());
+        assertEquals("demo.goharbor.com/v2/alpine/tags/list", containerRef.getTagsPath());
         assertNull(containerRef.getNamespace());
-        assertEquals("hello-world", containerRef.getRepository());
+        assertEquals("alpine", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());
         assertEquals("sha256:1234567890abcdef", containerRef.getDigest());
     }
 
     @Test
     void shouldParseImageWithNoTag() {
-        ContainerRef containerRef = ContainerRef.parse("docker.io/hello-world@sha256:1234567890abcdef");
+        ContainerRef containerRef = ContainerRef.parse("docker.io/alpine@sha256:1234567890abcdef");
         assertEquals("docker.io", containerRef.getRegistry());
-        assertNull(containerRef.getNamespace());
-        assertEquals("hello-world", containerRef.getRepository());
+        assertEquals("registry-1.docker.io/v2/alpine/tags/list", containerRef.getTagsPath());
+        assertEquals("library", containerRef.getNamespace());
+        assertEquals("alpine", containerRef.getRepository());
+        assertEquals("latest", containerRef.getTag());
+        assertEquals("sha256:1234567890abcdef", containerRef.getDigest());
+
+        containerRef = ContainerRef.parse("docker.io/foobar/alpine@sha256:1234567890abcdef");
+        assertEquals("registry-1.docker.io/v2/foobar/alpine/tags/list", containerRef.getTagsPath());
+        assertEquals("docker.io", containerRef.getRegistry());
+        assertEquals("foobar", containerRef.getNamespace());
+        assertEquals("alpine", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());
         assertEquals("sha256:1234567890abcdef", containerRef.getDigest());
     }
 
     @Test
     void shouldParseImageWithNoDigest() {
-        ContainerRef containerRef = ContainerRef.parse("docker.io/hello-world:latest");
+        ContainerRef containerRef = ContainerRef.parse("docker.io/alpine:latest");
         assertEquals("docker.io", containerRef.getRegistry());
-        assertNull(containerRef.getNamespace());
-        assertEquals("hello-world", containerRef.getRepository());
+        assertEquals("library", containerRef.getNamespace());
+        assertEquals("alpine", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());
         assertNull(containerRef.getDigest());
     }
 
     @Test
     void shouldParseImageWithNoRegistry() {
-        ContainerRef containerRef = ContainerRef.parse("hello-world:latest");
+        ContainerRef containerRef = ContainerRef.parse("alpine:latest");
         assertEquals("docker.io", containerRef.getRegistry());
         assertEquals("registry-1.docker.io", containerRef.getApiRegistry());
-        assertNull(containerRef.getNamespace());
-        assertEquals("hello-world", containerRef.getRepository());
+        assertEquals("registry-1.docker.io/v2/alpine/tags/list", containerRef.getTagsPath());
+        assertEquals("library", containerRef.getNamespace());
+        assertEquals("alpine", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());
         assertNull(containerRef.getDigest());
     }
 
     @Test
     void shouldParseImageWithNoTagAndNoRegistry() {
-        ContainerRef containerRef = ContainerRef.parse("hello-world");
+        ContainerRef containerRef = ContainerRef.parse("alpine");
         assertEquals("docker.io", containerRef.getRegistry());
-        assertNull(containerRef.getNamespace());
-        assertEquals("hello-world", containerRef.getRepository());
+        assertEquals("library", containerRef.getNamespace());
+        assertEquals("alpine", containerRef.getRepository());
+        assertEquals("latest", containerRef.getTag());
+        assertNull(containerRef.getDigest());
+
+        containerRef = ContainerRef.parse("foobar/alpine");
+        assertEquals("docker.io", containerRef.getRegistry());
+        assertEquals("foobar", containerRef.getNamespace());
+        assertEquals("alpine", containerRef.getRepository());
         assertEquals("latest", containerRef.getTag());
         assertNull(containerRef.getDigest());
     }
 
     @Test
-    void shouldGetTagsPath() {
+    void shouldGetTagsPathDockerIo() {
+        ContainerRef containerRef = ContainerRef.parse("docker.io/library/foo/alpine:latest@sha256:1234567890abcdef");
+        assertEquals("registry-1.docker.io/v2/library/foo/alpine/tags/list", containerRef.getTagsPath());
+    }
+
+    @Test
+    void shouldGetTagsPathOtherRegistry() {
         ContainerRef containerRef =
-                ContainerRef.parse("docker.io/library/foo/hello-world:latest@sha256:1234567890abcdef");
-        assertEquals("docker.io/v2/library/foo/hello-world/tags/list", containerRef.getTagsPath());
+                ContainerRef.parse("demo.goharbor.io/library/foo/alpine:latest@sha256:1234567890abcdef");
+        assertEquals("demo.goharbor.io/v2/library/foo/alpine/tags/list", containerRef.getTagsPath());
     }
 
     @Test

--- a/src/test/java/land/oras/ManifestTest.java
+++ b/src/test/java/land/oras/ManifestTest.java
@@ -78,6 +78,14 @@ public class ManifestTest {
     }
 
     @Test
+    void shouldHaveNoLayerForIndex() {
+        String json =
+                "{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1+json\",\"annotations\":{}}";
+        Manifest manifest = Manifest.fromJson(json);
+        assertEquals(0, manifest.getLayers().size());
+    }
+
+    @Test
     void shouldGetArtifactTest() {
         Manifest manifest1 = Manifest.empty().withArtifactType(ArtifactType.from("test/plain"));
         assertEquals("test/plain", manifest1.getArtifactType().getMediaType());


### PR DESCRIPTION
### Description

Use library namespace by default for docker.io images

Also found during interactive tests that multi-arch images are not exported (since an index is returned). An other PR will follow

### Testing done

CI and interactive tests with docker.io

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
