### PR TITLE
Save descriptor as-is on OCI layout

### DIFF
--- a/src/main/java/land/oras/Index.java
+++ b/src/main/java/land/oras/Index.java
@@ -35,6 +35,11 @@ public class Index {
     private final List<ManifestDescriptor> manifests;
 
     /**
+     * Original json
+     */
+    private transient String json;
+
+    /**
      * The manifest descriptor
      */
     private final transient ManifestDescriptor descriptor;
@@ -44,12 +49,14 @@ public class Index {
             String mediaType,
             String artifactType,
             List<ManifestDescriptor> manifests,
-            ManifestDescriptor descriptor) {
+            ManifestDescriptor descriptor,
+            String json) {
         this.schemaVersion = schemaVersion;
         this.mediaType = mediaType;
         this.descriptor = descriptor;
         this.artifactType = artifactType;
         this.manifests = manifests;
+        this.json = json;
     }
 
     /**
@@ -98,7 +105,17 @@ public class Index {
      * @return The manifest
      */
     public Index withDescriptor(ManifestDescriptor descriptor) {
-        return new Index(schemaVersion, mediaType, artifactType, manifests, descriptor);
+        return new Index(schemaVersion, mediaType, artifactType, manifests, descriptor, json);
+    }
+
+    /**
+     * Return same instance but with original JSON
+     * @param json The original JSON
+     * @return The index
+     */
+    private Index withJson(String json) {
+        this.json = json;
+        return this;
     }
 
     /**
@@ -110,12 +127,20 @@ public class Index {
     }
 
     /**
+     * Return the original JSON
+     * @return The original JSON
+     */
+    public String getJson() {
+        return json;
+    }
+
+    /**
      * Create a manifest from a JSON string
      * @param json The JSON string
      * @return The index
      */
     public static Index fromJson(String json) {
-        return JsonUtils.fromJson(json, Index.class);
+        return JsonUtils.fromJson(json, Index.class).withJson(json);
     }
 
     /**
@@ -124,6 +149,6 @@ public class Index {
      * @return The index
      */
     public static Index fromManifests(List<ManifestDescriptor> descriptors) {
-        return new Index(2, Const.DEFAULT_INDEX_MEDIA_TYPE, null, descriptors, null);
+        return new Index(2, Const.DEFAULT_INDEX_MEDIA_TYPE, null, descriptors, null, null);
     }
 }

--- a/src/main/java/land/oras/Manifest.java
+++ b/src/main/java/land/oras/Manifest.java
@@ -48,6 +48,11 @@ public final class Manifest {
      */
     private final transient ManifestDescriptor descriptor;
 
+    /**
+     * Original json
+     */
+    private transient String json;
+
     private Manifest(
             int schemaVersion,
             String mediaType,
@@ -56,7 +61,8 @@ public final class Manifest {
             Config config,
             Subject subject,
             List<Layer> layers,
-            Annotations annotations) {
+            Annotations annotations,
+            String json) {
         this.schemaVersion = schemaVersion;
         this.mediaType = mediaType;
         this.artifactType = artifactType != null ? artifactType.getMediaType() : null;
@@ -65,6 +71,7 @@ public final class Manifest {
         this.subject = subject;
         this.layers = layers;
         this.annotations = Map.copyOf(annotations.manifestAnnotations());
+        this.json = json;
     }
 
     /**
@@ -155,7 +162,8 @@ public final class Manifest {
                 config,
                 subject,
                 layers,
-                Annotations.ofManifest(annotations));
+                Annotations.ofManifest(annotations),
+                json);
     }
 
     /**
@@ -172,7 +180,8 @@ public final class Manifest {
                 config,
                 subject,
                 layers,
-                Annotations.ofManifest(annotations));
+                Annotations.ofManifest(annotations),
+                json);
     }
 
     /**
@@ -189,7 +198,8 @@ public final class Manifest {
                 config,
                 subject,
                 layers,
-                Annotations.ofManifest(annotations));
+                Annotations.ofManifest(annotations),
+                json);
     }
 
     /**
@@ -206,7 +216,8 @@ public final class Manifest {
                 config,
                 subject,
                 layers,
-                Annotations.ofManifest(annotations));
+                Annotations.ofManifest(annotations),
+                json);
     }
 
     /**
@@ -223,7 +234,8 @@ public final class Manifest {
                 config,
                 subject,
                 layers,
-                Annotations.ofManifest(annotations));
+                Annotations.ofManifest(annotations),
+                json);
     }
 
     /**
@@ -240,7 +252,18 @@ public final class Manifest {
                 config,
                 subject,
                 layers,
-                Annotations.ofManifest(annotations));
+                Annotations.ofManifest(annotations),
+                json);
+    }
+
+    /**
+     * Return same instance but with original JSON
+     * @param json The original JSON
+     * @return The index
+     */
+    private Manifest withJson(String json) {
+        this.json = json;
+        return this;
     }
 
     /**
@@ -257,7 +280,15 @@ public final class Manifest {
      * @return The manifest
      */
     public static Manifest fromJson(String json) {
-        return JsonUtils.fromJson(json, Manifest.class);
+        return JsonUtils.fromJson(json, Manifest.class).withJson(json);
+    }
+
+    /**
+     * Return the original JSON
+     * @return The original JSON
+     */
+    public String getJson() {
+        return json;
     }
 
     private @Nullable ArtifactType getTopLevelArtifactType() {
@@ -284,6 +315,7 @@ public final class Manifest {
                 Config.empty(),
                 null,
                 List.of(),
-                Annotations.empty());
+                Annotations.empty(),
+                null);
     }
 }

--- a/src/main/java/land/oras/utils/Const.java
+++ b/src/main/java/land/oras/utils/Const.java
@@ -49,6 +49,21 @@ public final class Const {
     public static final String DEFAULT_TAG = "latest";
 
     /**
+     * Index file in OCI layout
+     */
+    public static final String OCI_LAYOUT_INDEX = "index.json";
+
+    /**
+     * Layout folder in OCI layout
+     */
+    public static final String OCI_LAYOUT_FOLDER = "oci-layout";
+
+    /**
+     * Blobs folder in OCI layout
+     */
+    public static final String OCI_LAYOUT_BLOBS = "blobs";
+
+    /**
      * The default blob directory media type
      */
     public static final String DEFAULT_BLOB_DIR_MEDIA_TYPE = "application/vnd.oci.image.layer.v1.tar+gzip";

--- a/src/test/java/land/oras/RegistryTest.java
+++ b/src/test/java/land/oras/RegistryTest.java
@@ -685,6 +685,16 @@ public class RegistryTest {
                 .resolve("blobs")
                 .resolve("sha256")
                 .resolve(SupportedAlgorithm.getDigest(layer2.getDigest()))));
+
+        // Copy to oci layout again
+        registry.copy(containerRef, ociLayoutWithIndex);
+
+        // Check manifest exists
+        assertTrue(Files.exists(ociLayoutWithIndex
+                .resolve("blobs")
+                .resolve("sha256")
+                .resolve(SupportedAlgorithm.getDigest(
+                        pushedManifest.getDescriptor().getDigest()))));
     }
 
     @Test


### PR DESCRIPTION
Save descriptor as-is on OCI layout

### Description

Save descriptor as-is on OCI layout

### Testing done

CI

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
