### PR TITLE
Manifest annotations where not copied to index

### DIFF
--- a/src/main/java/land/oras/Annotations.java
+++ b/src/main/java/land/oras/Annotations.java
@@ -111,15 +111,6 @@ public record Annotations(
                             && !"$config".equals(entry.getKey())) // Filter out $manifest and $config
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
-
-        /**
-         * Get the annotations for a file
-         * @param key The key
-         * @return The annotations
-         */
-        public Map<String, String> getFileAnnotations(String key) {
-            return this.getOrDefault(key, new HashMap<>());
-        }
     }
 
     /**

--- a/src/main/java/land/oras/Index.java
+++ b/src/main/java/land/oras/Index.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import land.oras.utils.Const;
 import land.oras.utils.JsonUtils;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Index from an OCI layout
@@ -51,9 +52,10 @@ public final class Index extends Descriptor {
             String mediaType,
             String artifactType,
             List<ManifestDescriptor> manifests,
+            Map<String, String> annotations,
             ManifestDescriptor descriptor,
             String json) {
-        super(null, null, mediaType, Map.of(), artifactType);
+        super(null, null, mediaType, annotations, artifactType);
         this.schemaVersion = schemaVersion;
         this.descriptor = descriptor;
         this.manifests = manifests;
@@ -111,7 +113,7 @@ public final class Index extends Descriptor {
             newManifests.add(ManifestDescriptor.fromJson(descriptor.toJson()));
         }
         newManifests.add(manifest);
-        return new Index(schemaVersion, mediaType, artifactType, newManifests, descriptor, json);
+        return new Index(schemaVersion, mediaType, artifactType, newManifests, annotations, descriptor, json);
     }
 
     /**
@@ -123,12 +125,24 @@ public final class Index extends Descriptor {
     }
 
     /**
+     * Get the annotations
+     * @return The annotations
+     */
+    @Override
+    public @Nullable Map<String, String> getAnnotations() {
+        if (annotations != null && !annotations.isEmpty()) {
+            return annotations;
+        }
+        return null;
+    }
+
+    /**
      * Return a new index with the given descriptor
      * @param descriptor The descriptor
      * @return The manifest
      */
     public Index withDescriptor(ManifestDescriptor descriptor) {
-        return new Index(schemaVersion, mediaType, artifactType, manifests, descriptor, json);
+        return new Index(schemaVersion, mediaType, artifactType, manifests, annotations, descriptor, json);
     }
 
     /**
@@ -173,6 +187,6 @@ public final class Index extends Descriptor {
      * @return The index
      */
     public static Index fromManifests(List<ManifestDescriptor> descriptors) {
-        return new Index(2, Const.DEFAULT_INDEX_MEDIA_TYPE, null, descriptors, null, null);
+        return new Index(2, Const.DEFAULT_INDEX_MEDIA_TYPE, null, descriptors, null, null, null);
     }
 }

--- a/src/main/java/land/oras/OCILayout.java
+++ b/src/main/java/land/oras/OCILayout.java
@@ -38,6 +38,7 @@ import org.jspecify.annotations.Nullable;
  */
 public final class OCILayout extends OCI<LayoutRef> {
 
+    @SuppressWarnings("all")
     private final String imageLayoutVersion = "1.0.0";
 
     /**
@@ -134,6 +135,7 @@ public final class OCILayout extends OCI<LayoutRef> {
 
         ManifestDescriptor manifestDescriptor = ManifestDescriptor.of(
                         Const.DEFAULT_MANIFEST_MEDIA_TYPE, manifestDigest, manifestData.length)
+                .withAnnotations(manifest.getAnnotations().isEmpty() ? null : manifest.getAnnotations())
                 .withArtifactType(manifest.getArtifactType().getMediaType());
         if (layoutRef.getTag() != null) {
             manifestDescriptor = manifestDescriptor.withAnnotations(Map.of(Const.ANNOTATION_REF, layoutRef.getTag()));
@@ -546,6 +548,17 @@ public final class OCILayout extends OCI<LayoutRef> {
         if (!ref.getTag().equals(pathDigest)) {
             throw new OrasException("Digest mismatch: %s != %s".formatted(ref.getTag(), pathDigest));
         }
+    }
+
+    /**
+     * Return the OCI layout from the index.json file
+     * @param layoutPath The path to the layout containing the index.json file
+     * @return The OCI layout
+     */
+    public static OCILayout fromLayoutIndex(Path layoutPath) {
+        OCILayout layout = JsonUtils.fromJson(layoutPath.resolve(Const.OCI_LAYOUT_INDEX), OCILayout.class);
+        layout.path = layoutPath;
+        return layout;
     }
 
     /**

--- a/src/main/java/land/oras/utils/Const.java
+++ b/src/main/java/land/oras/utils/Const.java
@@ -119,11 +119,6 @@ public final class Const {
     public static final String DOCKER_INDEX_MEDIA_TYPE = "application/vnd.docker.distribution.manifest.list.v2+json";
 
     /**
-     * Docker legacy media type
-     */
-    public static final String DOCKER_LEGACY_MEDIA_TYPE = "application/vnd.docker.distribution.manifest.v1+prettyjws";
-
-    /**
      * The default manifest media type
      */
     public static final String DEFAULT_MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";

--- a/src/main/java/land/oras/utils/JsonUtils.java
+++ b/src/main/java/land/oras/utils/JsonUtils.java
@@ -35,8 +35,6 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import land.oras.exception.OrasException;
 import org.jspecify.annotations.NullMarked;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for JSON operations.
@@ -44,8 +42,6 @@ import org.slf4j.LoggerFactory;
  */
 @NullMarked
 public final class JsonUtils {
-
-    private static final Logger LOG = LoggerFactory.getLogger(JsonUtils.class);
 
     /**
      * Gson instance
@@ -106,7 +102,9 @@ public final class JsonUtils {
     }
 
     /**
-     * Convert a JSON string to an object
+     * Convert a JSON string to an object. Be careful when using this utility since the original JSON string is lost
+     * and might change content digest. Use this method only when the JSON string is not needed anymore or when the digest
+     * of the JSON string is not important.
      * @param path The path to the JSON file
      * @param clazz The class of the object
      * @param <T> The type of the object


### PR DESCRIPTION
Small issue I discovered comparing the java and go implementation

Test were indeed wrong

Manifest annotations where not copied to index

And added some cleanup

### Description

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
