### PR TITLE
Ensure to push blobs and config before manifests

### DIFF
--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -315,16 +315,6 @@ public final class Registry extends OCI<ContainerRef> {
         return manifest;
     }
 
-    /**
-     * Copy an artifact from one container to another
-     * @param targetRegistry The target registry
-     * @param sourceContainer The source container
-     * @param targetContainer The target container
-     */
-    public void copy(Registry targetRegistry, ContainerRef sourceContainer, ContainerRef targetContainer) {
-        throw new OrasException("Not implemented");
-    }
-
     @Override
     public Layer pushBlob(ContainerRef containerRef, Path blob, Map<String, String> annotations) {
         String digest = containerRef.getAlgorithm().digest(blob);


### PR DESCRIPTION
And restore/add tests for registry copy

### Description

Ensure to push blobs and config before manifests

### Testing done

mvn clean install

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
