### PR TITLE
Do not fail if XDG_RUNTIME_DIR is not set

### DIFF
--- a/src/main/java/land/oras/auth/AuthStore.java
+++ b/src/main/java/land/oras/auth/AuthStore.java
@@ -88,10 +88,14 @@ public class AuthStore {
      * @return FileStore instance.
      */
     public static AuthStore newStore() {
+        Path dockerPath = Path.of(System.getProperty("user.home"), ".docker", "config.json");
         List<Path> paths = List.of(
-                Path.of(System.getProperty("user.home"), ".docker", "config.json"), // Docker
-                Path.of(System.getenv("XDG_RUNTIME_DIR"), "containers", "auth.json") // Podman
-                );
+                dockerPath,
+                // default podman with fallback on docker config
+                // https://docs.podman.io/en/stable/markdown/podman-login.1.html#description
+                System.getenv("XDG_RUNTIME_DIR") != null
+                        ? Path.of(System.getenv("XDG_RUNTIME_DIR"), "containers", "auth.json")
+                        : dockerPath);
         return newStore(paths);
     }
 

--- a/src/test/java/land/oras/auth/AuthStoreTest.java
+++ b/src/test/java/land/oras/auth/AuthStoreTest.java
@@ -26,15 +26,24 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import land.oras.ContainerRef;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 class AuthStoreTest {
 
     @TempDir
     private Path tempDir;
+
+    @TempDir
+    private static Path homeDir;
+
+    @TempDir
+    private static Path xdgRuntimeDir;
 
     private AuthStore authStore;
     private AuthStore.Config mockConfig;
@@ -42,6 +51,48 @@ class AuthStoreTest {
     private ContainerRef SERVER_ADDRESS;
     private static final String USERNAME = "user";
     private static final String PASSWORD = "password";
+
+    // language=json
+    public static final String SAMPLE_DOCKER_CONFIG =
+            """
+    {
+        "auths": {
+            "registry.example.com": {
+                "auth": "dXNlcjpwYXNzd29yZA=="
+            },
+            "another.registry.com": {
+                "auth": "dXNlcjpwYXNzd29yZA=="
+            }
+        }
+    }
+    """;
+
+    // language=json
+    public static final String SAMPLE_PODMAN_CONFIG =
+            """
+    {
+        "auths": {
+            "registry.other.com": {
+                "auth": "dXNlcjpwYXNzd29yZA=="
+            },
+            "another.other.com": {
+                "auth": "dXNlcjpwYXNzd29yZA=="
+            }
+        }
+    }
+    """;
+
+    @BeforeAll
+    static void init() throws Exception {
+
+        // Write a sample Docker config file
+        Files.createDirectory(homeDir.resolve(".docker"));
+        Files.writeString(homeDir.resolve(".docker").resolve("config.json"), SAMPLE_DOCKER_CONFIG);
+
+        // Write a sample Podman config file
+        Files.createDirectory(xdgRuntimeDir.resolve("containers"));
+        Files.writeString(xdgRuntimeDir.resolve("containers").resolve("auth.json"), SAMPLE_PODMAN_CONFIG);
+    }
 
     @BeforeEach
     void setUp() {
@@ -61,10 +112,49 @@ class AuthStoreTest {
     }
 
     @Test
-    void testNewStore_defaultLocation_success() throws Exception {
-        // Simulate loading configuration from default location
-        AuthStore authStoreInstance = AuthStore.newStore();
-        assertNotNull(authStoreInstance);
+    void testShouldReadCredentialsFromDockerConfig() throws Exception {
+        new EnvironmentVariables().set("XDG_RUNTIME_DIR", "not-used").execute(() -> {
+            new SystemProperties("user.home", homeDir.toAbsolutePath().toString()).execute(() -> {
+                assertNotNull(System.getenv("XDG_RUNTIME_DIR"));
+                AuthStore authStoreInstance = AuthStore.newStore();
+                assertNotNull(authStoreInstance);
+
+                // Verify
+                AuthStore.Credential credential =
+                        authStoreInstance.get(ContainerRef.parse("registry.example.com/foo/bar:latest"));
+                assertNotNull(credential);
+                assertEquals(USERNAME, credential.username());
+            });
+        });
+    }
+
+    @Test
+    void testShouldReadCredentialsFromPodManConfig() throws Exception {
+        new EnvironmentVariables()
+                .set("XDG_RUNTIME_DIR", xdgRuntimeDir.toAbsolutePath().toString())
+                .execute(() -> {
+                    new SystemProperties("user.home", "not-used").execute(() -> {
+                        assertNotNull(System.getenv("XDG_RUNTIME_DIR"));
+                        assertEquals(xdgRuntimeDir.toAbsolutePath().toString(), System.getenv("XDG_RUNTIME_DIR"));
+                        AuthStore authStoreInstance = AuthStore.newStore();
+                        assertNotNull(authStoreInstance);
+
+                        // Verify
+                        AuthStore.Credential credential =
+                                authStoreInstance.get(ContainerRef.parse("registry.other.com/foo/bar:latest"));
+                        assertNotNull(credential);
+                        assertEquals(USERNAME, credential.username());
+                    });
+                });
+    }
+
+    @Test
+    void testWithoutXdgRuntimeDir() throws Exception {
+        new EnvironmentVariables().remove("XDG_RUNTIME_DIR").execute(() -> {
+            assertNull(System.getenv("XDG_RUNTIME_DIR"));
+            AuthStore authStoreInstance = AuthStore.newStore();
+            assertNotNull(authStoreInstance);
+        });
     }
 
     @Test


### PR DESCRIPTION
### Description

Do not fail if XDG_RUNTIME_DIR is not set

Fix https://github.com/oras-project/oras-java/issues/250

Also added a bit more tests that should help supporting better podman config to select correct credentials https://github.com/oras-project/oras-go/issues/918 and [containers-registries.conf](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md) based Container Registry alias etc....

### Testing done

mvn clean install and add/update tests

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
