### PR TITLE
Support for getting tags on OCI layout

### DIFF
--- a/src/main/java/land/oras/OCI.java
+++ b/src/main/java/land/oras/OCI.java
@@ -250,6 +250,13 @@ public abstract sealed class OCI<T extends Ref<@NonNull T>> permits Registry, OC
     }
 
     /**
+     * Get the tags for a ref
+     * @param ref The ref
+     * @return The tags
+     */
+    public abstract Tags getTags(T ref);
+
+    /**
      * Push an artifact
      * @param ref The container
      * @param artifactType The artifact type. Can be null

--- a/src/main/java/land/oras/OCILayout.java
+++ b/src/main/java/land/oras/OCILayout.java
@@ -285,6 +285,17 @@ public final class OCILayout extends OCI<LayoutRef> {
     }
 
     @Override
+    public Tags getTags(LayoutRef ref) {
+        Index index = Index.fromPath(getIndexPath());
+        String name = ref.getFolder().getFileName().toString();
+        List<String> tags = index.getManifests().stream()
+                .filter(m -> m.getAnnotations() != null && m.getAnnotations().containsKey(Const.ANNOTATION_REF))
+                .map(m -> m.getAnnotations().get(Const.ANNOTATION_REF))
+                .toList();
+        return new Tags(name, tags);
+    }
+
+    @Override
     public Referrers getReferrers(LayoutRef ref, @Nullable ArtifactType artifactType) {
         Index index = Index.fromPath(getIndexPath());
         ManifestDescriptor currentDescriptor = findManifestDescriptor(ref);

--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -122,12 +122,8 @@ public final class Registry extends OCI<ContainerRef> {
         return insecure ? "http" : "https";
     }
 
-    /**
-     * Get the tags of a container
-     * @param containerRef The container
-     * @return The tags
-     */
-    public List<String> getTags(ContainerRef containerRef) {
+    @Override
+    public Tags getTags(ContainerRef containerRef) {
         URI uri = URI.create("%s://%s".formatted(getScheme(), containerRef.getTagsPath()));
         OrasHttpClient.ResponseWrapper<String> response =
                 client.get(uri, Map.of(Const.ACCEPT_HEADER, Const.DEFAULT_JSON_MEDIA_TYPE));
@@ -135,7 +131,7 @@ public final class Registry extends OCI<ContainerRef> {
             response = client.get(uri, Map.of(Const.ACCEPT_HEADER, Const.DEFAULT_JSON_MEDIA_TYPE));
         }
         handleError(response);
-        return JsonUtils.fromJson(response.response(), Tags.class).tags();
+        return JsonUtils.fromJson(response.response(), Tags.class);
     }
 
     @Override

--- a/src/test/java/land/oras/OCILayoutTest.java
+++ b/src/test/java/land/oras/OCILayoutTest.java
@@ -128,6 +128,20 @@ public class OCILayoutTest {
     }
 
     @Test
+    void shouldListTags() throws Exception {
+        Path extractDir1 = extractDir.resolve("shouldListTags");
+        Files.createDirectory(extractDir1);
+
+        LayoutRef layoutRef = LayoutRef.parse("src/test/resources/oci/subject:latest");
+        OCILayout ociLayout =
+                OCILayout.Builder.builder().defaults(layoutRef.getFolder()).build();
+        Tags tags = ociLayout.getTags(layoutRef);
+        assertEquals("subject", tags.name());
+        assertEquals(1, tags.tags().size());
+        assertEquals("latest", tags.tags().get(0));
+    }
+
+    @Test
     void shouldPushConfig() throws IOException {
         Path path = layoutPath.resolve("shouldPushConfig");
         LayoutRef layoutRef = LayoutRef.parse("%s".formatted(path.toString()));

--- a/src/test/java/land/oras/RegistryWireMockTest.java
+++ b/src/test/java/land/oras/RegistryWireMockTest.java
@@ -148,7 +148,8 @@ public class RegistryWireMockTest {
 
         // Test
         List<String> tags = registry.getTags(ContainerRef.parse("%s/library/artifact-text"
-                .formatted(wmRuntimeInfo.getHttpBaseUrl().replace("http://", ""))));
+                        .formatted(wmRuntimeInfo.getHttpBaseUrl().replace("http://", ""))))
+                .tags();
 
         // Assert
         assertEquals(2, tags.size());
@@ -192,7 +193,8 @@ public class RegistryWireMockTest {
 
         // Test
         List<String> tags = registry.getTags(ContainerRef.parse("%s/library/artifact-text-store"
-                .formatted(wmRuntimeInfo.getHttpBaseUrl().replace("http://", ""))));
+                        .formatted(wmRuntimeInfo.getHttpBaseUrl().replace("http://", ""))))
+                .tags();
 
         // Assert
         assertEquals(2, tags.size());


### PR DESCRIPTION
### Description

Support for getting tags on OCI layout

Also breaking to return Tags object instead of a list of strings

### Testing done

mvn clean install and one automated tests

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
