### PR TITLE
Pass each time auth provider and handle token refresh on client instead of registry

### DIFF
--- a/src/main/java/land/oras/auth/AbstractUsernamePasswordProvider.java
+++ b/src/main/java/land/oras/auth/AbstractUsernamePasswordProvider.java
@@ -69,4 +69,9 @@ public abstract sealed class AbstractUsernamePasswordProvider implements AuthPro
     public String getAuthHeader(ContainerRef registry) {
         return "Basic " + java.util.Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
     }
+
+    @Override
+    public AuthScheme getAuthScheme() {
+        return AuthScheme.BASIC;
+    }
 }

--- a/src/main/java/land/oras/auth/AuthScheme.java
+++ b/src/main/java/land/oras/auth/AuthScheme.java
@@ -20,26 +20,23 @@
 
 package land.oras.auth;
 
-import land.oras.ContainerRef;
-import org.jspecify.annotations.Nullable;
-
 /**
- * Interface for auth provider
- * Must return the authentication header to pass to HTTP requests
+ * Enum for authentication schemes
  */
-public interface AuthProvider {
+public enum AuthScheme {
 
     /**
-     * Get the authentication header for this provider
-     * @param registry The registry
-     * @return The authentication header or null if not applicable
+     * No authentication
      */
-    @Nullable
-    String getAuthHeader(ContainerRef registry);
+    NONE,
 
     /**
-     * Get the authentication scheme for this provider
-     * @return The authentication scheme
+     * Basic authentication
      */
-    AuthScheme getAuthScheme();
+    BASIC,
+
+    /**
+     * Bearer authentication
+     */
+    BEARER,
 }

--- a/src/main/java/land/oras/auth/AuthStoreAuthenticationProvider.java
+++ b/src/main/java/land/oras/auth/AuthStoreAuthenticationProvider.java
@@ -59,4 +59,9 @@ public final class AuthStoreAuthenticationProvider implements AuthProvider {
         }
         return new UsernamePasswordProvider(credential.username(), credential.password()).getAuthHeader(registry);
     }
+
+    @Override
+    public AuthScheme getAuthScheme() {
+        return AuthScheme.BASIC;
+    }
 }

--- a/src/main/java/land/oras/auth/BearerTokenProvider.java
+++ b/src/main/java/land/oras/auth/BearerTokenProvider.java
@@ -20,18 +20,8 @@
 
 package land.oras.auth;
 
-import java.net.URI;
-import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import land.oras.ContainerRef;
-import land.oras.exception.OrasException;
-import land.oras.utils.Const;
-import land.oras.utils.JsonUtils;
-import land.oras.utils.OrasHttpClient;
+import land.oras.utils.HttpClient;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -44,12 +34,6 @@ import org.slf4j.LoggerFactory;
 public final class BearerTokenProvider implements AuthProvider {
 
     /**
-     * The pattern for the WWW-Authenticate header value
-     */
-    private static final Pattern WWW_AUTH_VALUE_PATTERN =
-            Pattern.compile("Bearer realm=\"([^\"]+)\",service=\"([^\"]+)\",scope=\"([^\"]+)\"(,error=\"([^\"]+)\")?");
-
-    /**
      * Logger
      */
     private static final Logger LOG = LoggerFactory.getLogger(BearerTokenProvider.class);
@@ -57,105 +41,40 @@ public final class BearerTokenProvider implements AuthProvider {
     /**
      * The refreshed token
      */
-    private @Nullable TokenResponse token;
-
-    /**
-     * The provider for username and password in case of refresh token done
-     */
-    private final AuthProvider provider;
+    private HttpClient.@Nullable TokenResponse token;
 
     /**
      * Create a new bearer token provider
-     * @param provider The provider for username and password
      */
-    public BearerTokenProvider(AuthProvider provider) {
-        this.provider = provider;
-    }
-
-    /**
-     * Retrieve
-     * @param response The response
-     * @param client The original client
-     * @param containerRef The container reference
-     * @return The token
-     */
-    public BearerTokenProvider refreshToken(
-            ContainerRef containerRef, OrasHttpClient client, OrasHttpClient.ResponseWrapper<String> response) {
-
-        String wwwAuthHeader = response.headers().getOrDefault(Const.WWW_AUTHENTICATE_HEADER.toLowerCase(), "");
-        LOG.debug("WWW-Authenticate header: {}", wwwAuthHeader);
-        if (wwwAuthHeader.isEmpty()) {
-            throw new OrasException("No WWW-Authenticate header found in response");
-        }
-
-        Matcher matcher = WWW_AUTH_VALUE_PATTERN.matcher(wwwAuthHeader);
-        if (!matcher.matches()) {
-            throw new OrasException("Invalid WWW-Authenticate header value: " + wwwAuthHeader);
-        }
-
-        // Extract parts
-        String realm = matcher.group(1);
-        String service = matcher.group(2);
-        String scope = matcher.group(3);
-        String error = matcher.group(5);
-
-        LOG.debug("WWW-Authenticate header: realm={}, service={}, scope={}, error={}", realm, service, scope, error);
-
-        URI uri = URI.create(realm + "?scope=" + scope + "&service=" + service);
-
-        // Perform the request to get the token
-        Map<String, String> headers = new HashMap<>();
-        String authHeader = provider.getAuthHeader(containerRef);
-        if (authHeader != null) {
-            headers.put(Const.AUTHORIZATION_HEADER, authHeader);
-        }
-        OrasHttpClient.ResponseWrapper<String> responseWrapper = client.get(uri, headers);
-
-        // Log the response
-        LOG.debug(
-                "Response: {}",
-                responseWrapper
-                        .response()
-                        .replaceAll("\"token\"\\s*:\\s*\"([A-Za-z0-9\\-_\\.]+)\"", "\"token\":\"<redacted>\"")
-                        .replaceAll(
-                                "\"access_token\"\\s*:\\s*\"([A-Za-z0-9\\-_\\.]+)\"",
-                                "\"access_token\":\"<redacted>\""));
-        LOG.debug(
-                "Headers: {}",
-                responseWrapper.headers().entrySet().stream()
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey,
-                                entry -> Const.AUTHORIZATION_HEADER.equalsIgnoreCase(entry.getKey())
-                                        ? "<redacted" // Replace value with ****
-                                        : entry.getValue())));
-
-        this.token = JsonUtils.fromJson(responseWrapper.response(), TokenResponse.class);
-        return this;
-    }
+    public BearerTokenProvider() {}
 
     /**
      * Get the token
      * @return The token
      */
-    public @Nullable TokenResponse getToken() {
+    public HttpClient.@Nullable TokenResponse getToken() {
         return token;
+    }
+
+    /**
+     * Set the token
+     * @param token The token
+     */
+    public void setToken(HttpClient.TokenResponse token) {
+        this.token = token;
     }
 
     @Override
     public @Nullable String getAuthHeader(ContainerRef registry) {
         if (token == null) {
+            LOG.debug("No token available. No header will be set.");
             return null;
         }
-        return "Bearer " + token.token;
+        return "Bearer " + token.token();
     }
 
-    /**
-     * The token response
-     * @param token The token
-     * @param access_token The access token
-     * @param expire_in The expire in
-     * @param issued_at The issued at
-     */
-    @NullMarked
-    public record TokenResponse(String token, String access_token, Integer expire_in, ZonedDateTime issued_at) {}
+    @Override
+    public AuthScheme getAuthScheme() {
+        return AuthScheme.BEARER;
+    }
 }

--- a/src/main/java/land/oras/auth/NoAuthProvider.java
+++ b/src/main/java/land/oras/auth/NoAuthProvider.java
@@ -36,4 +36,9 @@ public final class NoAuthProvider implements AuthProvider {
     public String getAuthHeader(ContainerRef registry) {
         return null;
     }
+
+    @Override
+    public AuthScheme getAuthScheme() {
+        return AuthScheme.NONE;
+    }
 }

--- a/src/main/java/land/oras/exception/OrasException.java
+++ b/src/main/java/land/oras/exception/OrasException.java
@@ -20,8 +20,8 @@
 
 package land.oras.exception;
 
+import land.oras.utils.HttpClient;
 import land.oras.utils.JsonUtils;
-import land.oras.utils.OrasHttpClient;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -60,7 +60,7 @@ public class OrasException extends RuntimeException {
      * New exception with a message and a response
      * @param response The response
      */
-    public OrasException(OrasHttpClient.ResponseWrapper<String> response) {
+    public OrasException(HttpClient.ResponseWrapper<String> response) {
         this("Response code: " + response.statusCode());
         try {
             this.statusCode = response.statusCode();

--- a/src/test/java/land/oras/auth/BearerTokenProviderTest.java
+++ b/src/test/java/land/oras/auth/BearerTokenProviderTest.java
@@ -20,168 +20,23 @@
 
 package land.oras.auth;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doReturn;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import java.time.ZonedDateTime;
-import java.util.Map;
 import land.oras.ContainerRef;
-import land.oras.exception.OrasException;
-import land.oras.utils.Const;
-import land.oras.utils.JsonUtils;
-import land.oras.utils.OrasHttpClient;
-import land.oras.utils.RegistryContainer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.mockito.Mockito;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-@WireMockTest
 @Execution(ExecutionMode.SAME_THREAD)
 public class BearerTokenProviderTest {
-
-    @Container
-    private final RegistryContainer registry = new RegistryContainer().withStartupAttempts(3);
 
     private final ContainerRef containerRef = ContainerRef.parse("localhost:5000/library/test:latest");
 
     @Test
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    void shouldRefreshToken(WireMockRuntimeInfo wmRuntimeInfo) {
-
-        // Mock responses
-        OrasHttpClient.ResponseWrapper mockResponse = Mockito.mock(OrasHttpClient.ResponseWrapper.class);
-        BearerTokenProvider.TokenResponse tokenResponse =
-                new BearerTokenProvider.TokenResponse("fake-token", "access-token", 300, ZonedDateTime.now());
-        WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.register(WireMock.get(WireMock.urlEqualTo(
-                        "/token?scope=repository:library/test:pull&service=%s".formatted(registry.getRegistry())))
-                .willReturn(WireMock.okJson(JsonUtils.toJson(tokenResponse))));
-
-        // Return WWW-Authenticate header from registry
-        Mockito.when(mockResponse.headers())
-                .thenReturn(Map.of(
-                        Const.WWW_AUTHENTICATE_HEADER.toLowerCase(),
-                        String.format(
-                                "Bearer realm=\"%s/token\",service=\"%s\",scope=\"repository:library/test:pull\"",
-                                wmRuntimeInfo.getHttpBaseUrl(), registry.getRegistry())));
-
-        // Test
-        BearerTokenProvider provider = new BearerTokenProvider(new UsernamePasswordProvider("user", "password"));
-        provider.refreshToken(containerRef, OrasHttpClient.Builder.builder().build(), mockResponse);
-        BearerTokenProvider.TokenResponse token = provider.getToken();
-
-        // Assert tokens
-        assertEquals("fake-token", token.token());
-        assertEquals("access-token", token.access_token());
-        assertEquals(300, token.expire_in());
-        assertEquals(tokenResponse.issued_at(), token.issued_at());
-
-        // Check the token header is set
-        assertEquals("Bearer fake-token", provider.getAuthHeader(containerRef));
-    }
-
-    @Test
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    void shouldTestTokenWithNoAuth(WireMockRuntimeInfo wmRuntimeInfo) {
-
-        // Mock responses
-        OrasHttpClient.ResponseWrapper mockResponse = Mockito.mock(OrasHttpClient.ResponseWrapper.class);
-        BearerTokenProvider.TokenResponse tokenResponse =
-                new BearerTokenProvider.TokenResponse("fake-token", "access-token", 300, ZonedDateTime.now());
-        WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.register(WireMock.get(WireMock.urlEqualTo(
-                        "/token?scope=repository:library/test:pull&service=%s".formatted(registry.getRegistry())))
-                .willReturn(WireMock.okJson(JsonUtils.toJson(tokenResponse))));
-
-        // Return WWW-Authenticate header from registry
-        Mockito.when(mockResponse.headers())
-                .thenReturn(Map.of(
-                        Const.WWW_AUTHENTICATE_HEADER.toLowerCase(),
-                        String.format(
-                                "Bearer realm=\"%s/token\",service=\"%s\",scope=\"repository:library/test:pull\"",
-                                wmRuntimeInfo.getHttpBaseUrl(), registry.getRegistry())));
-
-        // Test
-        BearerTokenProvider provider = new BearerTokenProvider(new NoAuthProvider());
-        provider.refreshToken(containerRef, OrasHttpClient.Builder.builder().build(), mockResponse);
-        BearerTokenProvider.TokenResponse token = provider.getToken();
-
-        // Assert tokens
-        assertEquals("fake-token", token.token());
-        assertEquals("access-token", token.access_token());
-        assertEquals(300, token.expire_in());
-        assertEquals(tokenResponse.issued_at(), token.issued_at());
-
-        // Check the token header is set
-        assertEquals("Bearer fake-token", provider.getAuthHeader(containerRef));
-    }
-
-    @Test
-    void testNoRefreshedToken() {
-        BearerTokenProvider provider = new BearerTokenProvider(new UsernamePasswordProvider("user", "password"));
+    void shouldHaveNoAuthHeader() {
+        BearerTokenProvider provider = new BearerTokenProvider();
         assertNull(provider.getAuthHeader(containerRef), "No token should be returned");
-    }
-
-    @Test
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    void testInvalidWwwAuthentication() {
-        OrasHttpClient.ResponseWrapper mockResponse = Mockito.mock(OrasHttpClient.ResponseWrapper.class);
-        BearerTokenProvider provider = new BearerTokenProvider(new UsernamePasswordProvider("user", "password"));
-        ContainerRef containerRef = ContainerRef.parse("localhost:5000/library/test:latest");
-        assertThrows(OrasException.class, () -> {
-            provider.refreshToken(containerRef, OrasHttpClient.Builder.builder().build(), mockResponse);
-        });
-        doReturn(Map.of(Const.WWW_AUTHENTICATE_HEADER.toLowerCase(), "invalid"))
-                .when(mockResponse)
-                .headers();
-        assertThrows(OrasException.class, () -> {
-            provider.refreshToken(containerRef, OrasHttpClient.Builder.builder().build(), mockResponse);
-        });
-    }
-
-    @Test
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    void testWWWAuthenticateFormat(WireMockRuntimeInfo wmRuntimeInfo) {
-        OrasHttpClient.ResponseWrapper mockResponse = Mockito.mock(OrasHttpClient.ResponseWrapper.class);
-
-        BearerTokenProvider.TokenResponse tokenResponse =
-                new BearerTokenProvider.TokenResponse("fake-token", "access-token", 300, ZonedDateTime.now());
-        WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.register(WireMock.get(WireMock.urlMatching("/token(.*)"))
-                .willReturn(WireMock.okJson(JsonUtils.toJson(tokenResponse))));
-
-        BearerTokenProvider provider = new BearerTokenProvider(new UsernamePasswordProvider("user", "password"));
-        assertThrows(OrasException.class, () -> {
-            provider.refreshToken(containerRef, OrasHttpClient.Builder.builder().build(), mockResponse);
-        });
-
-        // Without error
-        doReturn(Map.of(
-                        Const.WWW_AUTHENTICATE_HEADER.toLowerCase(),
-                        "Bearer realm=\"%s/token\",service=\"%s\",scope=\"repository:repository/library:push,pull\""
-                                .formatted(wmRuntimeInfo.getHttpBaseUrl(), registry.getRegistry())))
-                .when(mockResponse)
-                .headers();
-        // No exception should be thrown
-        provider.refreshToken(containerRef, OrasHttpClient.Builder.builder().build(), mockResponse);
-
-        // With error
-        doReturn(Map.of(
-                        Const.WWW_AUTHENTICATE_HEADER.toLowerCase(),
-                        "Bearer realm=\"%s/token\",service=\"%s\",scope=\"repository/library:push,pull\",error=\"insufficient_scope\""
-                                .formatted(wmRuntimeInfo.getHttpBaseUrl(), registry.getRegistry())))
-                .when(mockResponse)
-                .headers();
-        // No exception should be thrown
-        provider.refreshToken(containerRef, OrasHttpClient.Builder.builder().build(), mockResponse);
     }
 }

--- a/src/test/java/land/oras/exception/OrasExceptionTest.java
+++ b/src/test/java/land/oras/exception/OrasExceptionTest.java
@@ -25,8 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
+import land.oras.utils.HttpClient;
 import land.oras.utils.JsonUtils;
-import land.oras.utils.OrasHttpClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -46,7 +46,7 @@ public class OrasExceptionTest {
 
     @Test
     void shouldWrapResponse() {
-        OrasHttpClient.ResponseWrapper<String> response = new OrasHttpClient.ResponseWrapper<>(
+        HttpClient.ResponseWrapper<String> response = new HttpClient.ResponseWrapper<>(
                 JsonUtils.toJson(new Error("5001", "foo", "the details")), 500, Map.of());
         OrasException orasException = new OrasException(response);
 
@@ -61,8 +61,7 @@ public class OrasExceptionTest {
 
     @Test
     void shouldWrapInvalidResponse() {
-        OrasHttpClient.ResponseWrapper<String> response =
-                new OrasHttpClient.ResponseWrapper<>("corrupted", 500, Map.of());
+        HttpClient.ResponseWrapper<String> response = new HttpClient.ResponseWrapper<>("corrupted", 500, Map.of());
         OrasException orasException = new OrasException(response);
         assertEquals("Response code: 500", orasException.getMessage(), "Message should be correct");
         assertNull(orasException.getError(), "Error should be null");


### PR DESCRIPTION
### Description

Pass each time auth provider and handle token refresh on client instead of registry

Partially fix https://github.com/oras-project/oras-java/issues/17 but without token caching

This is not performance since the token will be requested on each request. 

Just parking this PR here

### Testing done

mvn clean

Missing automated and interactive tests

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
