### PR TITLE
Missing redirect after getting auth token

### DIFF
--- a/src/test/java/land/oras/DockerIoITCase.java
+++ b/src/test/java/land/oras/DockerIoITCase.java
@@ -22,9 +22,15 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DockerIoITCase {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void shouldPullAnonymousIndex() {
@@ -44,5 +50,15 @@ public class DockerIoITCase {
         ContainerRef containerRef3 = ContainerRef.parse("alpine");
         Index index3 = registry.getIndex(containerRef3);
         assertNotNull(index3);
+    }
+
+    @Test
+    void shouldPullOneBlob() throws IOException {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse("jbangdev/jbang-action");
+        Manifest manifest = registry.getManifest(containerRef1);
+        Layer oneLayer = manifest.getLayers().get(0);
+        registry.fetchBlob(containerRef1.withDigest(oneLayer.getDigest()), tempDir.resolve("my-blob"));
+        assertNotNull(tempDir.resolve("my-blob"));
     }
 }

--- a/src/test/java/land/oras/GitHubContainerRegistryITCase.java
+++ b/src/test/java/land/oras/GitHubContainerRegistryITCase.java
@@ -22,9 +22,15 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class GitHubContainerRegistryITCase {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void shouldPullIndex() {
@@ -32,5 +38,17 @@ public class GitHubContainerRegistryITCase {
         ContainerRef containerRef1 = ContainerRef.parse("ghcr.io/oras-project/oras:main");
         Index index = registry.getIndex(containerRef1);
         assertNotNull(index);
+    }
+
+    @Test
+    void shouldPullOneBlob() throws IOException {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse("ghcr.io/oras-project/oras:main");
+        Index index = registry.getIndex(containerRef1);
+        Manifest manifest = registry.getManifest(
+                containerRef1.withDigest(index.getManifests().get(1).getDigest())); // Just take first manifest
+        Layer oneLayer = manifest.getLayers().get(0);
+        registry.fetchBlob(containerRef1.withDigest(oneLayer.getDigest()), tempDir.resolve("my-blob"));
+        assertNotNull(tempDir.resolve("my-blob"));
     }
 }

--- a/src/test/java/land/oras/JFrogArtifactoryITCase.java
+++ b/src/test/java/land/oras/JFrogArtifactoryITCase.java
@@ -22,9 +22,15 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class JFrogArtifactoryITCase {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void shouldPull() {
@@ -32,5 +38,15 @@ public class JFrogArtifactoryITCase {
         ContainerRef containerRef1 = ContainerRef.parse("releases-docker.jfrog.io/jfrog/jfrog-cli-v2-jf");
         Manifest manifest = registry.getManifest(containerRef1);
         assertNotNull(manifest);
+    }
+
+    @Test
+    void shouldPullOneBlob() throws IOException {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse("releases-docker.jfrog.io/jfrog/jfrog-cli-v2-jf");
+        Manifest manifest = registry.getManifest(containerRef1);
+        Layer oneLayer = manifest.getLayers().get(0);
+        registry.fetchBlob(containerRef1.withDigest(oneLayer.getDigest()), tempDir.resolve("my-blob"));
+        assertNotNull(tempDir.resolve("my-blob"));
     }
 }


### PR DESCRIPTION
### Description

Probably regression of https://github.com/oras-project/oras-java/pull/273/files

Redirect was not done after redoing the request after getting auth token

### Testing done

Added one Wiremock and one Docker.io test

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
