### PR TITLE
Partial validate of `Docker-Content-Digest` when downloading or getting blob

### DIFF
--- a/src/main/java/land/oras/LayoutRef.java
+++ b/src/main/java/land/oras/LayoutRef.java
@@ -130,7 +130,7 @@ public final class LayoutRef extends Ref<LayoutRef> {
             return SupportedAlgorithm.getDefault();
         }
         // See https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
-        else if (SupportedAlgorithm.matchPattern(tag)) {
+        else if (SupportedAlgorithm.isSupported(tag)) {
             return SupportedAlgorithm.fromDigest(tag);
         }
 
@@ -145,7 +145,7 @@ public final class LayoutRef extends Ref<LayoutRef> {
         if (tag == null) {
             return false;
         }
-        return SupportedAlgorithm.matchPattern(tag);
+        return SupportedAlgorithm.isSupported(tag);
     }
 
     @Override

--- a/src/main/java/land/oras/OCILayout.java
+++ b/src/main/java/land/oras/OCILayout.java
@@ -432,7 +432,7 @@ public final class OCILayout extends OCI<LayoutRef> {
         if (ref.getTag() == null) {
             throw new OrasException("Tag is required to get blob from layout");
         }
-        boolean isDigest = SupportedAlgorithm.matchPattern(ref.getTag());
+        boolean isDigest = SupportedAlgorithm.isSupported(ref.getTag());
         if (isDigest) {
             SupportedAlgorithm algorithm = SupportedAlgorithm.fromDigest(ref.getTag());
             return getBlobPath().resolve(algorithm.getPrefix()).resolve(SupportedAlgorithm.getDigest(ref.getTag()));
@@ -552,7 +552,7 @@ public final class OCILayout extends OCI<LayoutRef> {
         if (ref.getTag() == null) {
             throw new OrasException("Missing ref");
         }
-        if (!SupportedAlgorithm.matchPattern(ref.getTag())) {
+        if (!SupportedAlgorithm.isSupported(ref.getTag())) {
             throw new OrasException("Unsupported digest: %s".formatted(ref.getTag()));
         }
         SupportedAlgorithm algorithm = SupportedAlgorithm.fromDigest(ref.getTag());

--- a/src/test/java/land/oras/DockerIoITCase.java
+++ b/src/test/java/land/oras/DockerIoITCase.java
@@ -26,7 +26,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class DockerIoITCase {
 
     @TempDir

--- a/src/test/java/land/oras/GitHubContainerRegistryITCase.java
+++ b/src/test/java/land/oras/GitHubContainerRegistryITCase.java
@@ -26,7 +26,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class GitHubContainerRegistryITCase {
 
     @TempDir

--- a/src/test/java/land/oras/JFrogArtifactoryITCase.java
+++ b/src/test/java/land/oras/JFrogArtifactoryITCase.java
@@ -26,7 +26,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class JFrogArtifactoryITCase {
 
     @TempDir

--- a/src/test/java/land/oras/LayoutRefTest.java
+++ b/src/test/java/land/oras/LayoutRefTest.java
@@ -54,11 +54,14 @@ public class LayoutRefTest {
     @Test
     void shouldParseLayoutWithDigest() {
         String ociLayout = tempDir.resolve("foo").toString();
-        LayoutRef layoutRef = LayoutRef.parse("%s@sha256:12345".formatted(ociLayout));
-        assertEquals("sha256:12345", layoutRef.getTag());
+        LayoutRef layoutRef = LayoutRef.parse(
+                "%s@sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824".formatted(ociLayout));
+        assertEquals("sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", layoutRef.getTag());
         assertEquals(ociLayout, layoutRef.getFolder().toString());
         assertEquals(ociLayout, layoutRef.getRepository());
-        assertTrue(layoutRef.isValidDigest(), "sha256:12345 should be a valid digest pattern");
+        assertTrue(
+                layoutRef.isValidDigest(),
+                "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 should be a valid digest pattern");
     }
 
     @Test
@@ -85,9 +88,10 @@ public class LayoutRefTest {
     void shouldGetAlgorithm() {
         LayoutRef layoutRef = LayoutRef.parse("foo");
         assertEquals("sha256", layoutRef.getAlgorithm().getPrefix());
-        layoutRef = LayoutRef.parse("foo@sha256:12345");
+        layoutRef = LayoutRef.parse("foo@sha256:");
         assertEquals("sha256", layoutRef.getAlgorithm().getPrefix());
-        layoutRef = LayoutRef.parse("foo@sha512:12345");
+        layoutRef = LayoutRef.parse(
+                "foo@sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
         assertEquals("sha512", layoutRef.getAlgorithm().getPrefix());
     }
 }

--- a/src/test/java/land/oras/utils/SupportedAlgorithmTest.java
+++ b/src/test/java/land/oras/utils/SupportedAlgorithmTest.java
@@ -126,6 +126,28 @@ public class SupportedAlgorithmTest {
 
         // Not match
         assertFalse(SupportedAlgorithm.matchPattern("latest"));
+
+        // Invalid size for all algorithms
+        assertEquals(
+                "Invalid digest sha1:1234, expected size is 20, but got 4",
+                assertThrows(OrasException.class, () -> SupportedAlgorithm.isSupported("sha1:1234"))
+                        .getMessage());
+        assertEquals(
+                "Invalid digest sha256:1234, expected size is 32, but got 4",
+                assertThrows(OrasException.class, () -> SupportedAlgorithm.isSupported("sha256:1234"))
+                        .getMessage());
+        assertEquals(
+                "Invalid digest sha384:1234, expected size is 48, but got 4",
+                assertThrows(OrasException.class, () -> SupportedAlgorithm.isSupported("sha384:1234"))
+                        .getMessage());
+        assertEquals(
+                "Invalid digest sha512:1234, expected size is 64, but got 4",
+                assertThrows(OrasException.class, () -> SupportedAlgorithm.isSupported("sha512:1234"))
+                        .getMessage());
+        assertEquals(
+                "Invalid digest blake3:1234, expected size is 32, but got 4",
+                assertThrows(OrasException.class, () -> SupportedAlgorithm.isSupported("blake3:1234"))
+                        .getMessage());
     }
 
     @Test


### PR DESCRIPTION
### Description

Validate `Docker-Content-Digest` when downloading or getting blob

### Testing done



### Submitter checklist
- [ ] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [ ] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
