### PR TITLE
Only send a single 'Authorization' header after getting a token

### DIFF
--- a/src/main/java/land/oras/auth/HttpClient.java
+++ b/src/main/java/land/oras/auth/HttpClient.java
@@ -490,7 +490,7 @@ public final class HttpClient {
                         token.issued_at().plusSeconds(token.expires_in()));
             }
             try {
-                builder = builder.header(Const.AUTHORIZATION_HEADER, "Bearer " + token.token());
+                builder = builder.setHeader(Const.AUTHORIZATION_HEADER, "Bearer " + token.token());
                 HttpResponse<T> newResponse = client.send(builder.build(), handler);
 
                 // Follow redirect


### PR DESCRIPTION

<!--
 DO NOT DELETE

 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 -->

### Description

When using basic authentication (username & password) to get a token via the `WWW-Authenticate` mechanism, the newly aquired token is added as an `Authorization` header on the request, resulting in two `Authorization` headers: one containing the username/password (`Authorization: Basic ...`) and one containing the token (`Authorization: Bearer ...`).

Some servers will reject a request with multiple `Authorization` headers.

These changes modify the behaviour so that, instead of adding an additional header, the bearer token replaces the username/password `Authorization` header.

### Testing done

I checked that only a single `Authorization` header (containing the token) is sent on requests after using basic authentication to acquire a token. The requests were able to successfully authenticate with a server which was rejecting requests with multiple headers.

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
