### PR TITLE
Updatecli configuration

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,31 @@
+name: updatecli
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * 1' # Every Monday at 2am UTC
+  push:
+  pull_request:
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'oras-project'
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@1536e372d5f433385f11b5b133b23a9833c510ce # v2.86.0
+
+      - name: Run Updatecli in Dry Run mode
+        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Updatecli in Apply mode
+        if: github.ref == 'refs/heads/main'
+        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -1,0 +1,71 @@
+---
+name: Bump the Maven
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  mavenLatestVersion:
+    kind: githubrelease
+    spec:
+      owner: "apache"
+      repository: "maven"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "~3"
+    transformers:
+      - trimprefix: "maven-"
+
+targets:
+  updatePom:
+    name: "Update the value in the pom.xml file"
+    kind: file
+    sourceid: mavenLatestVersion
+    spec:
+      file: pom.xml
+      matchPattern: "<version>\\[(\\d.\\d.\\d),\\)</version>"
+      replacePattern: '<version>[{{ source "mavenLatestVersion" }},)</version>'
+    scmid: default
+  updateSdkmanRC:
+    name: "Update the value in the .sdkmanrc file"
+    kind: file
+    sourceid: mavenLatestVersion
+    spec:
+      file: .sdkmanrc
+      matchPattern: "maven=(\\d.\\d.\\d)"
+      replacePattern: 'maven={{ source "mavenLatestVersion" }}'
+    scmid: default
+  updateWorkflowFiles:
+    name: "Update the value in the .sdkmanrc file"
+    kind: file
+    sourceid: mavenLatestVersion
+    spec:
+      files:
+        - .github/workflows/build.yml
+        - .github/workflows/deploy-javadoc.yml
+        - .github/workflows/deploy-snapshots.yml
+        - .github/workflows/release.yml
+      matchPattern: "maven-version: (\\d.\\d.\\d)"
+      replacePattern: 'maven-version: {{ source "mavenLatestVersion" }}'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Bump Maven {{ source "mavenLatestVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - Dockerfile

--- a/updatecli/values.github-action.yaml
+++ b/updatecli/values.github-action.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "github-actions[bot]"
+  email: "41898282+github-actions[bot]@users.noreply.github.com"
+  username: "github-actions"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  owner: "oras-project"
+  repository: "oras-java"


### PR DESCRIPTION
### Description

Updatecli configuration

In order to bump maven version on all files

### Testing done

```
updatecli diff --values updatecli/values.github-action.yaml -c updatecli/updatecli.d/maven.yaml
```

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
