### PR TITLE
Fix typo on updatecli permissions

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -6,9 +6,9 @@ on:
   push:
   pull_request:
 jobs:
-  permissions:
-    actions: write
   updatecli:
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     if: github.repository_owner == 'oras-project'
     steps:


### PR DESCRIPTION
### Description

Fix typo on updatecli permissions

### Testing done

None

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
