### PR TITLE
Fix regex for maven to allow 2 digits

### DIFF
--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -34,7 +34,7 @@ targets:
     sourceid: mavenLatestVersion
     spec:
       file: pom.xml
-      matchPattern: "<version>\\[(\\d.\\d.\\d),\\)</version>"
+      matchPattern: "<version>\\[(\\d.\\d.\\d{1,2}),\\)</version>"
       replacePattern: '<version>[{{ source "mavenLatestVersion" }},)</version>'
     scmid: default
   updateSdkmanRC:
@@ -43,7 +43,7 @@ targets:
     sourceid: mavenLatestVersion
     spec:
       file: .sdkmanrc
-      matchPattern: "maven=(\\d.\\d.\\d)"
+      matchPattern: "maven=(\\d.\\d.\\d{1,2})"
       replacePattern: 'maven={{ source "mavenLatestVersion" }}'
     scmid: default
   updateWorkflowFiles:
@@ -52,7 +52,7 @@ targets:
     sourceid: mavenLatestVersion
     spec:
       file: .github/vars/maven-version.txt
-      matchPattern: "(\\d.\\d.\\d)"
+      matchPattern: "(\\d.\\d.\\d{1,2})"
       replacePattern: '{{ source "mavenLatestVersion" }}'
     scmid: default
 


### PR DESCRIPTION
### Description

Fix regex for maven to allow 2 digits

### Testing done

```
updatecli diff --values updatecli/values.github-action.yaml -c updatecli/updatecli.d/maven.yaml
```

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
