### PR TITLE
Do not include auth header when redirecting to other domain or when switching to insecure protocol

### DIFF
--- a/src/test/java/land/oras/AnnotationsTest.java
+++ b/src/test/java/land/oras/AnnotationsTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class AnnotationsTest {
+class AnnotationsTest {
 
     @Test
     public void fromJson() {

--- a/src/test/java/land/oras/ArtifactTypeTest.java
+++ b/src/test/java/land/oras/ArtifactTypeTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class ArtifactTypeTest {
+class ArtifactTypeTest {
 
     @Test
     void validateArtifactType() {

--- a/src/test/java/land/oras/ClassAnnotationsTest.java
+++ b/src/test/java/land/oras/ClassAnnotationsTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class ClassAnnotationsTest {
+class ClassAnnotationsTest {
 
     @Test
     void shouldHaveAnnotationOnModel() {

--- a/src/test/java/land/oras/ConfigTest.java
+++ b/src/test/java/land/oras/ConfigTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class ConfigTest {
+class ConfigTest {
 
     @Test
     void shouldSerializeEmptyConfig() {

--- a/src/test/java/land/oras/DockerIoITCase.java
+++ b/src/test/java/land/oras/DockerIoITCase.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class DockerIoITCase {
+class DockerIoITCase {
 
     @TempDir
     Path tempDir;

--- a/src/test/java/land/oras/GitHubContainerRegistryITCase.java
+++ b/src/test/java/land/oras/GitHubContainerRegistryITCase.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class GitHubContainerRegistryITCase {
+class GitHubContainerRegistryITCase {
 
     @TempDir
     Path tempDir;

--- a/src/test/java/land/oras/HarborS3ITCase.java
+++ b/src/test/java/land/oras/HarborS3ITCase.java
@@ -18,24 +18,31 @@
  * =LICENSEEND=
  */
 
-package land.oras.exception;
+package land.oras;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.nio.file.Path;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-class ErrorTest {
+class HarborS3ITCase {
+
+    @TempDir
+    Path tempDir;
 
     @Test
-    void shouldHaveCorrectValues() {
-        Error error = new Error("code", "message", "details");
-
-        // Getters
-        assertEquals("code", error.code(), "Code should be correct");
-        assertEquals("message", error.message(), "Message should be correct");
-        assertEquals("details", error.details(), "Details should be correct");
+    @Disabled("Only to test with demo Harbor S3 instance")
+    void shouldPullOneBlob() {
+        Registry registry = Registry.builder().defaults().build();
+        ContainerRef containerRef1 = ContainerRef.parse("demo.goharbor.io/oras/lib:foo");
+        Manifest manifest = registry.getManifest(containerRef1);
+        Layer oneLayer = manifest.getLayers().get(0);
+        registry.fetchBlob(containerRef1.withDigest(oneLayer.getDigest()), tempDir.resolve("my-blob"));
+        assertNotNull(tempDir.resolve("my-blob"));
     }
 }

--- a/src/test/java/land/oras/IndexTest.java
+++ b/src/test/java/land/oras/IndexTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class IndexTest {
+class IndexTest {
 
     @Test
     void shouldReadAndWriteIndex() {

--- a/src/test/java/land/oras/JFrogArtifactoryITCase.java
+++ b/src/test/java/land/oras/JFrogArtifactoryITCase.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class JFrogArtifactoryITCase {
+class JFrogArtifactoryITCase {
 
     @TempDir
     Path tempDir;

--- a/src/test/java/land/oras/LayerTest.java
+++ b/src/test/java/land/oras/LayerTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class LayerTest {
+class LayerTest {
 
     @TempDir
     public static Path tempDir;

--- a/src/test/java/land/oras/LayoutRefTest.java
+++ b/src/test/java/land/oras/LayoutRefTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class LayoutRefTest {
+class LayoutRefTest {
 
     @TempDir
     public static Path tempDir;

--- a/src/test/java/land/oras/LocalPathTest.java
+++ b/src/test/java/land/oras/LocalPathTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class LocalPathTest {
+class LocalPathTest {
 
     @TempDir
     private Path blobDir;

--- a/src/test/java/land/oras/ManifestDescriptorTest.java
+++ b/src/test/java/land/oras/ManifestDescriptorTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class ManifestDescriptorTest {
+class ManifestDescriptorTest {
 
     @Test
     void shouldSetAnnotations() {

--- a/src/test/java/land/oras/ManifestTest.java
+++ b/src/test/java/land/oras/ManifestTest.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class ManifestTest {
+class ManifestTest {
 
     /**
      * Logger

--- a/src/test/java/land/oras/OCILayoutTest.java
+++ b/src/test/java/land/oras/OCILayoutTest.java
@@ -44,7 +44,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @Execution(ExecutionMode.CONCURRENT)
-public class OCILayoutTest {
+class OCILayoutTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(OCILayoutTest.class);
 

--- a/src/test/java/land/oras/QuayIoITCase.java
+++ b/src/test/java/land/oras/QuayIoITCase.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 
-public class QuayIoITCase {
+class QuayIoITCase {
 
     @Test
     void shouldPull() {

--- a/src/test/java/land/oras/RegistryTest.java
+++ b/src/test/java/land/oras/RegistryTest.java
@@ -47,7 +47,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @Execution(ExecutionMode.CONCURRENT)
-public class RegistryTest {
+class RegistryTest {
 
     @Container
     private final ZotContainer registry = new ZotContainer().withStartupAttempts(3);

--- a/src/test/java/land/oras/SubjectTest.java
+++ b/src/test/java/land/oras/SubjectTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class SubjectTest {
+class SubjectTest {
 
     @Test
     void shouldReadSubject() {

--- a/src/test/java/land/oras/auth/BearerTokenProviderTest.java
+++ b/src/test/java/land/oras/auth/BearerTokenProviderTest.java
@@ -30,7 +30,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @Execution(ExecutionMode.SAME_THREAD)
-public class BearerTokenProviderTest {
+class BearerTokenProviderTest {
 
     private final ContainerRef containerRef = ContainerRef.parse("localhost:5000/library/test:latest");
 

--- a/src/test/java/land/oras/auth/HttpClientTest.java
+++ b/src/test/java/land/oras/auth/HttpClientTest.java
@@ -1,0 +1,112 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2025 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class HttpClientTest {
+
+    @Test
+    void testIsSameOriginSame() {
+        URI uri1 = URI.create("https://example.com:443/path");
+        URI uri2 = URI.create("https://example.com/path2");
+        assertTrue(HttpClient.isSameOrigin(uri1, uri2));
+    }
+
+    @Test
+    void testIsSameOriginDifferentPort() {
+        URI uri1 = URI.create("http://example.com:8080");
+        URI uri2 = URI.create("http://example.com");
+        assertFalse(HttpClient.isSameOrigin(uri1, uri2));
+    }
+
+    @Test
+    void testIsSameOriginDifferentScheme() {
+        URI uri1 = URI.create("http://example.com");
+        URI uri2 = URI.create("https://example.com");
+        assertFalse(HttpClient.isSameOrigin(uri1, uri2));
+    }
+
+    @Test
+    void testIsSameOriginDifferentHost() {
+        URI uri1 = URI.create("http://example.com");
+        URI uri2 = URI.create("http://example.org");
+        assertFalse(HttpClient.isSameOrigin(uri1, uri2));
+    }
+
+    @Test
+    void testGetPortExplicit() {
+        URI uri = URI.create("http://example.com:8080");
+        assertEquals(8080, HttpClient.getPort(uri));
+    }
+
+    @Test
+    void testGetPortDefaultHttp() {
+        URI uri = URI.create("http://example.com");
+        assertEquals(80, HttpClient.getPort(uri));
+    }
+
+    @Test
+    void testGetPortDefaultHttps() {
+        URI uri = URI.create("https://example.com");
+        assertEquals(443, HttpClient.getPort(uri));
+    }
+
+    @Test
+    void testShouldRedirectTrue301() {
+        HttpResponse<?> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(HttpURLConnection.HTTP_MOVED_PERM);
+        assertTrue(HttpClient.shouldRedirect(response));
+    }
+
+    @Test
+    void testShouldRedirectTrue302() {
+        HttpResponse<?> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(HttpURLConnection.HTTP_MOVED_TEMP);
+        assertTrue(HttpClient.shouldRedirect(response));
+    }
+
+    @Test
+    void testShouldRedirectTrue307() {
+        HttpResponse<?> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(307);
+        assertTrue(HttpClient.shouldRedirect(response));
+    }
+
+    @Test
+    void testShouldRedirectFalse() {
+        HttpResponse<?> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        assertFalse(HttpClient.shouldRedirect(response));
+    }
+}

--- a/src/test/java/land/oras/auth/NoAuthProviderTest.java
+++ b/src/test/java/land/oras/auth/NoAuthProviderTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class NoAuthProviderTest {
+class NoAuthProviderTest {
 
     @Test
     void shouldHaveNoAuthHeader() {

--- a/src/test/java/land/oras/auth/ScopeUtilsTest.java
+++ b/src/test/java/land/oras/auth/ScopeUtilsTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class ScopeUtilsTest {
+class ScopeUtilsTest {
 
     @Test
     void shouldAppendRepositoryScope() {

--- a/src/test/java/land/oras/auth/ScopesTest.java
+++ b/src/test/java/land/oras/auth/ScopesTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
  * Test for {@link Scopes}.
  */
 @Execution(ExecutionMode.CONCURRENT)
-public class ScopesTest {
+class ScopesTest {
 
     @Test
     void shouldBuildScopes() {

--- a/src/test/java/land/oras/auth/UsernamePasswordProviderTest.java
+++ b/src/test/java/land/oras/auth/UsernamePasswordProviderTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class UsernamePasswordProviderTest {
+class UsernamePasswordProviderTest {
 
     @Test
     void shouldReturnCorrectValues() {

--- a/src/test/java/land/oras/exception/OrasExceptionTest.java
+++ b/src/test/java/land/oras/exception/OrasExceptionTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class OrasExceptionTest {
+class OrasExceptionTest {
 
     @Test
     void shouldWrapException() {


### PR DESCRIPTION
### Description

Do not send credentials to other demain. Also now S3 reject Authorization header when signature is passed throught URL

```xml
<Error>
  <Code>InvalidArgument</Code>
  <Message>Only one auth mechanism allowed; only the X-Amz-Algorithm query parameter, Signature query string parameter or the Authorization header should be specified</Message>
</Error>
```

### Testing done

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [ ] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
