### PR TITLE
Ensure to include parent folder into archive

### DIFF
--- a/src/main/java/land/oras/OCI.java
+++ b/src/main/java/land/oras/OCI.java
@@ -167,11 +167,15 @@ public abstract sealed class OCI<T extends Ref<@NonNull T>> permits Registry, OC
                         ref = ref.withDigest(ref.getAlgorithm().digest(tempArchive.getPath()));
                     }
                     try (InputStream is = Files.newInputStream(tempArchive.getPath())) {
+                        String title = path.getPath().isAbsolute()
+                                ? path.getPath().getFileName().toString()
+                                : path.getPath().toString();
+                        LOG.debug("Uploading directory as archive with title: {}", title);
                         Layer layer = pushBlob(ref, is)
                                 .withMediaType(path.getMediaType())
                                 .withAnnotations(Map.of(
                                         Const.ANNOTATION_TITLE,
-                                        path.getPath().getFileName().toString(),
+                                        title,
                                         Const.ANNOTATION_ORAS_CONTENT_DIGEST,
                                         ref.getAlgorithm().digest(tempTar.getPath()),
                                         Const.ANNOTATION_ORAS_UNPACK,

--- a/src/main/java/land/oras/utils/ArchiveUtils.java
+++ b/src/main/java/land/oras/utils/ArchiveUtils.java
@@ -93,6 +93,7 @@ public final class ArchiveUtils {
      */
     public static LocalPath tar(LocalPath sourceDir) {
         Path tarFile = createTempTar();
+        boolean isAbsolute = sourceDir.getPath().isAbsolute();
         try (OutputStream fos = Files.newOutputStream(tarFile);
 
                 // Output stream chain
@@ -104,8 +105,8 @@ public final class ArchiveUtils {
                 paths.forEach(path -> {
                     LOG.trace("Visiting path: {}", path);
                     try {
-
-                        Path relativePath = sourceDir.getPath().relativize(path);
+                        Path baseName = isAbsolute ? sourceDir.getPath().getFileName() : sourceDir.getPath();
+                        Path relativePath = baseName.resolve(sourceDir.getPath().relativize(path));
                         if (relativePath.toString().isEmpty()) {
                             LOG.trace("Skipping root directory: {}", path);
                             return;

--- a/src/test/java/land/oras/ZotLocalhostITCase.java
+++ b/src/test/java/land/oras/ZotLocalhostITCase.java
@@ -1,0 +1,38 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2025 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class ZotLocalhostITCase {
+
+    @Test
+    @Disabled("Only to test using localhost:5000 container")
+    void shouldPushArtifactAndPullWithOrasCli() {
+        Registry registry = Registry.builder().insecure().build();
+        ContainerRef containerRef1 = ContainerRef.parse("localhost:5000/foo:java");
+        registry.pushArtifact(containerRef1, LocalPath.of("src/main/java"));
+    }
+}

--- a/src/test/java/land/oras/utils/ArchiveUtilsTest.java
+++ b/src/test/java/land/oras/utils/ArchiveUtilsTest.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Execution(ExecutionMode.CONCURRENT)
-public class ArchiveUtilsTest {
+class ArchiveUtilsTest {
 
     /**
      * Logger
@@ -155,34 +155,35 @@ public class ArchiveUtilsTest {
         // Untar to temporary
         Path tmp = ArchiveUtils.untar(archive.getPath());
         assertTrue(Files.exists(tmp), "Temp should exist");
-        assertTrue(Files.exists(tmp.resolve("dir1")), "dir1 should exist");
+        assertTrue(Files.exists(tmp.resolve(directory.getPath().getFileName()).resolve("dir1")), "dir1 should exist");
 
         // Ensure all files are extracted
-        assertTrue(Files.exists(targetGzDir.resolve("dir1")), "dir1 should exist");
-        assertTrue(Files.exists(targetGzDir.resolve("dir2")), "dir2 should exist");
-        assertTrue(Files.exists(targetGzDir.resolve("dir1").resolve("file1")), "file1 should exist");
-        assertTrue(Files.exists(targetGzDir.resolve("dir2").resolve("file2")), "file2 should exist");
-        assertTrue(Files.exists(targetGzDir.resolve("dir1").resolve("file3")), "file3 should exist");
-        assertTrue(Files.exists(targetGzDir.resolve("dir2").resolve("dir3")), "dir3 should exist");
-        assertTrue(Files.exists(targetGzDir.resolve("dir2").resolve("dir3").resolve("file4")), "file4 should exist");
+        Path extractedDir = targetGzDir.resolve(directory.getPath().getFileName());
+        assertTrue(Files.exists(extractedDir.resolve("dir1")), "dir1 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir2")), "dir2 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir1").resolve("file1")), "file1 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir2").resolve("file2")), "file2 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir1").resolve("file3")), "file3 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir2").resolve("dir3")), "dir3 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir2").resolve("dir3").resolve("file4")), "file4 should exist");
 
         // Empty directory
-        assertTrue(Files.exists(targetGzDir.resolve("empty")), "empty should exist");
+        assertTrue(Files.exists(extractedDir.resolve("empty")), "empty should exist");
 
         // Assert file content
         assertTrue(
-                Files.readString(targetGzDir.resolve("dir1").resolve("file1")).equals("file1"),
+                Files.readString(extractedDir.resolve("dir1").resolve("file1")).equals("file1"),
                 "file1 content should match");
         assertTrue(
-                Files.readString(targetGzDir.resolve("dir2").resolve("file2")).equals("file2"),
+                Files.readString(extractedDir.resolve("dir2").resolve("file2")).equals("file2"),
                 "file2 content should match");
         assertTrue(
-                Files.readString(targetGzDir.resolve("dir2").resolve("dir3").resolve("file4"))
+                Files.readString(extractedDir.resolve("dir2").resolve("dir3").resolve("file4"))
                         .equals("file4"),
                 "file4 content should match");
 
         // Ensure symlink is extracted
-        assertTrue(Files.isSymbolicLink(targetGzDir.resolve("dir1").resolve("file3")), "file3 should be symlink");
+        assertTrue(Files.isSymbolicLink(extractedDir.resolve("dir1").resolve("file3")), "file3 should be symlink");
 
         // To temporary
         Path temp = ArchiveUtils.uncompressuntar(compressedArchive, directory.getMediaType());
@@ -207,34 +208,35 @@ public class ArchiveUtilsTest {
         // Untar to temporary
         Path tmp = ArchiveUtils.untar(archive.getPath());
         assertTrue(Files.exists(tmp), "Temp should exist");
-        assertTrue(Files.exists(tmp.resolve("dir1")), "dir1 should exist");
+        assertTrue(Files.exists(tmp.resolve(directory.getPath().getFileName()).resolve("dir1")), "dir1 should exist");
 
         // Ensure all files are extracted
-        assertTrue(Files.exists(targetZstdDir.resolve("dir1")), "dir1 should exist");
-        assertTrue(Files.exists(targetZstdDir.resolve("dir2")), "dir2 should exist");
-        assertTrue(Files.exists(targetZstdDir.resolve("dir1").resolve("file1")), "file1 should exist");
-        assertTrue(Files.exists(targetZstdDir.resolve("dir2").resolve("file2")), "file2 should exist");
-        assertTrue(Files.exists(targetZstdDir.resolve("dir1").resolve("file3")), "file3 should exist");
-        assertTrue(Files.exists(targetZstdDir.resolve("dir2").resolve("dir3")), "dir3 should exist");
-        assertTrue(Files.exists(targetZstdDir.resolve("dir2").resolve("dir3").resolve("file4")), "file4 should exist");
+        Path extractedDir = targetZstdDir.resolve(directory.getPath().getFileName());
+        assertTrue(Files.exists(extractedDir.resolve("dir1")), "dir1 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir2")), "dir2 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir1").resolve("file1")), "file1 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir2").resolve("file2")), "file2 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir1").resolve("file3")), "file3 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir2").resolve("dir3")), "dir3 should exist");
+        assertTrue(Files.exists(extractedDir.resolve("dir2").resolve("dir3").resolve("file4")), "file4 should exist");
 
         // Empty directory
-        assertTrue(Files.exists(targetZstdDir.resolve("empty")), "empty should exist");
+        assertTrue(Files.exists(extractedDir.resolve("empty")), "empty should exist");
 
         // Assert file content
         assertTrue(
-                Files.readString(targetZstdDir.resolve("dir1").resolve("file1")).equals("file1"),
+                Files.readString(extractedDir.resolve("dir1").resolve("file1")).equals("file1"),
                 "file1 content should match");
         assertTrue(
-                Files.readString(targetZstdDir.resolve("dir2").resolve("file2")).equals("file2"),
+                Files.readString(extractedDir.resolve("dir2").resolve("file2")).equals("file2"),
                 "file2 content should match");
         assertTrue(
-                Files.readString(targetZstdDir.resolve("dir2").resolve("dir3").resolve("file4"))
+                Files.readString(extractedDir.resolve("dir2").resolve("dir3").resolve("file4"))
                         .equals("file4"),
                 "file4 content should match");
 
         // Ensure symlink is extracted
-        assertTrue(Files.isSymbolicLink(targetZstdDir.resolve("dir1").resolve("file3")), "file3 should be symlink");
+        assertTrue(Files.isSymbolicLink(extractedDir.resolve("dir1").resolve("file3")), "file3 should be symlink");
 
         // To temporary
         Path temp = ArchiveUtils.uncompressuntar(compressedArchive, directory.getMediaType());


### PR DESCRIPTION
### Description

Also fix nested folder. Previously only the folder name was taken which was not consistent with Go SDK

For example pushing `src/main/java` correctly set the title to `src/main/java`

Absolute path are also kept with original behavior (folder name). Expect they are not correctly packaged

```json
    "layers": [
        {
            "annotations": {
                "io.deis.oras.content.digest": "sha256:13e37d5391939b4f2b1f43a2f0966ec2b02266555e0399d7dd40208a98bb987b",
                "io.deis.oras.content.unpack": "true",
                "org.opencontainers.image.title": "src/main/java"
            },
            "digest": "sha256:eddce30abed45c67998e27aeb250542576ecdf0e95afa9c843dbca3521bf22b0",
            "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
            "size": 40871
        }
    ],
```

And is correctly pullable with oras pull

```
oras pull localhost:5000/foo:java
✓ Pulled      src/main/java                                                                                                                                                           39.9/39.9 KB 100.00%    9ms
  └─ sha256:eddce30abed45c67998e27aeb250542576ecdf0e95afa9c843dbca3521bf22b0
✓ Pulled      application/vnd.oci.image.manifest.v1+json                                                                                                                                741/741  B 100.00%     0s
  └─ sha256:a00a547cc8e8d23f398aaeb000ebdb542822fc303475cff8229d917aca1ee908
Pulled [registry] localhost:5000/foo:java
Digest: sha256:a00a547cc8e8d23f398aaeb000ebdb542822fc303475cff8229d917aca1ee908
```


### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
