### PR TITLE
Fix maven maven on deploy-javadoc

### DIFF
--- a/.github/workflows/deploy-javadoc.yml
+++ b/.github/workflows/deploy-javadoc.yml
@@ -28,7 +28,7 @@ jobs:
           checkout-enabled: false
           java-distribution: 'temurin'
           java-version: 17
-          maven-version: ${{ steps.maven.outputs.version }}
+          maven-version: ${{ steps.maven-version.outputs.version }}
           cache-enabled: true
 
       - name: Build javadoc


### PR DESCRIPTION
### Description

Small typo. Fix maven maven on deploy-javadoc

### Testing done

None in particular

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
