### PR TITLE
[release/0.2.x] Bump io.github.classgraph:classgraph from 4.8.181 to 4.8.184 (#422)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <wiremock.version>3.13.1</wiremock.version>
     <mockito.version>5.20.0</mockito.version>
     <system.stubs.version>2.1.8</system.stubs.version>
-    <classgraph.version>4.8.181</classgraph.version>
+    <classgraph.version>4.8.184</classgraph.version>
 
     <!-- Plugin version -->
     <palantir.java.format.version>2.74.0</palantir.java.format.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/0.2.x`:
 - [Bump io.github.classgraph:classgraph from 4.8.181 to 4.8.184 (#422)](https://github.com/oras-project/oras-java/pull/422)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)