### PR TITLE
[release/0.2.x] Bump org.jacoco:jacoco-maven-plugin from 0.8.13 to 0.8.14 (#426)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <!-- Plugin version -->
     <palantir.java.format.version>2.74.0</palantir.java.format.version>
     <build.helper-maven-plugin.version>3.6.1</build.helper-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
     <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
     <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
     <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/0.2.x`:
 - [Bump org.jacoco:jacoco-maven-plugin from 0.8.13 to 0.8.14 (#426)](https://github.com/oras-project/oras-java/pull/426)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)