### PR TITLE
Support of unqualified-search-registries in registries.conf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,10 @@
       <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>tools.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-toml</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/src/main/java/land/oras/auth/RegistriesConf.java
+++ b/src/main/java/land/oras/auth/RegistriesConf.java
@@ -1,0 +1,138 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2025 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import land.oras.exception.OrasException;
+import land.oras.utils.TomlUtils;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handle registries.conf configuration
+ */
+@NullMarked
+public class RegistriesConf {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RegistriesConf.class);
+
+    /**
+     * The internal config
+     */
+    private final Config config;
+
+    /**
+     * Constructor for RegistriesConf.
+     *
+     * @param config configuration instance.
+     */
+    RegistriesConf(Config config) {
+        this.config = Objects.requireNonNull(config, "Config cannot be null");
+    }
+
+    /**
+     * Create a new RegistriesConf instance by loading configuration from the specified paths.
+     * @param configPaths The list of paths to load configuration from.
+     * @return A new RegistriesConf instance.
+     */
+    public static RegistriesConf newConf(List<Path> configPaths) {
+
+        // Take the first path found: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md
+        for (Path configPath : configPaths) {
+            LOG.debug("Checking for registries config file at: {}", configPath);
+            if (Files.exists(configPath)) {
+                ConfigFile configFile = TomlUtils.fromToml(configPath, ConfigFile.class);
+                LOG.debug("Loaded registries config file: {}", configPath);
+                return new RegistriesConf(Config.load(configFile));
+            }
+        }
+        // Empty config
+        return new RegistriesConf(new Config());
+    }
+
+    /**
+     * Create a new RegistriesConf instance by loading configuration from standard paths.
+     * @return A new RegistriesConf instance.
+     */
+    public static RegistriesConf newConf() {
+        Path globalPath = Path.of("/etc/containers/registries.conf");
+        List<Path> paths = List.of(
+                System.getenv("HOME") != null
+                        ? Path.of(System.getenv("HOME"), ".config", "containers", "registries.conf")
+                        : globalPath,
+                globalPath);
+        return newConf(paths);
+    }
+
+    /**
+     * The model of the config file
+     *
+     */
+    record ConfigFile(@JsonProperty("unqualified-search-registries") @Nullable List<String> unqualifiedRegistries) {}
+
+    /**
+     * Get the list of unqualified registries.
+     * @return an unmodifiable list of unqualified registries.
+     */
+    public List<String> getUnqualifiedRegistries() {
+        return Collections.unmodifiableList(config.unqualifiedRegistries);
+    }
+
+    /**
+     * Nested Config class for configuration management.
+     */
+    static class Config {
+
+        /**
+         * Private constructor to prevent instantiation.
+         */
+        private Config() {}
+
+        /**
+         * List of unqualified registries.
+         */
+        private final List<String> unqualifiedRegistries = new LinkedList<>();
+
+        /**
+         * Loads the configuration from a TOML file at the specified path and populates registries configuration
+         *
+         * @param configFile The config file
+         * @return A {@code Config} object populated with config
+         * @throws OrasException If an error occurs while reading or parsing the TOML file.
+         */
+        public static Config load(ConfigFile configFile) throws OrasException {
+            Config config = new Config();
+            if (configFile.unqualifiedRegistries != null) {
+                LOG.debug("Loading unqualified registries: {}", configFile.unqualifiedRegistries);
+                config.unqualifiedRegistries.addAll(configFile.unqualifiedRegistries);
+            }
+            return config;
+        }
+    }
+}

--- a/src/main/java/land/oras/utils/TomlUtils.java
+++ b/src/main/java/land/oras/utils/TomlUtils.java
@@ -1,0 +1,99 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2025 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.utils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import land.oras.exception.OrasException;
+import org.jspecify.annotations.NullMarked;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.toml.TomlMapper;
+
+/**
+ * Utility class for TOML operations.
+ * Use Jackson 3 internally for TOML operations
+ */
+@NullMarked
+public final class TomlUtils {
+
+    /**
+     * TOML mapper instance
+     */
+    private static final ObjectMapper tomlMapper;
+
+    /**
+     * Utils class
+     */
+    private TomlUtils() {
+        // Hide constructor
+    }
+
+    static {
+        tomlMapper = TomlMapper.builder().build();
+    }
+
+    /**
+     * Convert an object to a TOML string
+     * @param object The object to convert
+     * @return The TOML string
+     */
+    public static String toToml(Object object) {
+        try {
+            return tomlMapper.writeValueAsString(object);
+        } catch (JacksonException e) {
+            throw new OrasException("Unable to convert object to TOML string", e);
+        }
+    }
+
+    /**
+     * Convert a TOML string to an object
+     * @param toml The TOML string
+     * @param clazz The class of the object
+     * @param <T> The type of the object
+     * @return The object
+     */
+    public static <T> T fromToml(String toml, Class<T> clazz) {
+        try {
+            return tomlMapper.readValue(toml, clazz);
+        } catch (JacksonException e) {
+            throw new OrasException("Unable to parse TOML string", e);
+        }
+    }
+
+    /**
+     * Read a TOML file and convert its contents to an object.
+     * The file at the given {@code path} is read as UTF-8 TOML and deserialized into the specified type.
+     * @param path The path to the TOML file
+     * @param clazz The class of the object
+     * @param <T> The type of the object
+     * @return The object deserialized from the TOML file
+     */
+    public static <T> T fromToml(Path path, Class<T> clazz) {
+        try {
+            return tomlMapper.readValue(Files.readString(path, StandardCharsets.UTF_8), clazz);
+        } catch (IOException | JacksonException e) {
+            throw new OrasException("Unable to read TOML from file", e);
+        }
+    }
+}

--- a/src/test/java/land/oras/DockerIoITCase.java
+++ b/src/test/java/land/oras/DockerIoITCase.java
@@ -22,7 +22,6 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -36,32 +35,44 @@ class DockerIoITCase {
     Path tempDir;
 
     @Test
-    void shouldPullAnonymousIndex() {
+    void shouldPullAnonymousIndexFQDN() {
 
         // FQDN
         Registry registry = Registry.builder().build();
-        ContainerRef containerRef1 = ContainerRef.parse("docker.io/library/alpine");
-        Index index = registry.getIndex(containerRef1);
+        ContainerRef containerRef = ContainerRef.parse("docker.io/library/alpine");
+        Index index = registry.getIndex(containerRef);
         assertNotNull(index);
+    }
 
-        // Default registry
-        ContainerRef containerRef2 = ContainerRef.parse("library/alpine");
-        Index index2 = registry.getIndex(containerRef2);
-        assertNotNull(index2);
-
+    @Test
+    void shouldPullAnonymousIndexDefaultRegistryAndNamespace() {
         // Simple name
-        ContainerRef containerRef3 = ContainerRef.parse("alpine");
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef3 = ContainerRef.parse("library/alpine");
         Index index3 = registry.getIndex(containerRef3);
         assertNotNull(index3);
     }
 
     @Test
-    void shouldPullOneBlob() throws IOException {
+    void shouldPullAnonymousIndexUnqualified() {
+
+        // Simple name
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef = ContainerRef.parse("alpine");
+        Index index3 = registry.getIndex(containerRef);
+        assertNotNull(index3);
+    }
+
+    @Test
+    void shouldPullOneBlob() {
         Registry registry = Registry.builder().build();
         ContainerRef containerRef1 = ContainerRef.parse("jbangdev/jbang-action");
         Manifest manifest = registry.getManifest(containerRef1);
+        String effectiveRegistry = containerRef1.getEffectiveRegistry(registry);
         Layer oneLayer = manifest.getLayers().get(0);
-        registry.fetchBlob(containerRef1.withDigest(oneLayer.getDigest()), tempDir.resolve("my-blob"));
+        registry.fetchBlob(
+                containerRef1.forRegistry(effectiveRegistry).withDigest(oneLayer.getDigest()),
+                tempDir.resolve("my-blob"));
         assertNotNull(tempDir.resolve("my-blob"));
     }
 }

--- a/src/test/java/land/oras/auth/AuthStoreTest.java
+++ b/src/test/java/land/oras/auth/AuthStoreTest.java
@@ -35,6 +35,9 @@ import org.mockito.Mockito;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
+/**
+ * Test class of {@link AuthStore}.
+ */
 class AuthStoreTest {
 
     @TempDir
@@ -123,15 +126,6 @@ class AuthStoreTest {
         mockConfig = Mockito.mock(AuthStore.Config.class);
         mockCredential = new AuthStore.Credential(USERNAME, PASSWORD);
         authStore = new AuthStore(mockConfig);
-    }
-
-    @Test
-    void testNewStore_success() throws Exception {
-        // Simulate loading configuration
-        AuthStore.Config mockConfig = Mockito.mock(AuthStore.Config.class);
-        AuthStore authStoreInstance = new AuthStore(mockConfig);
-
-        assertNotNull(authStoreInstance);
     }
 
     @Test

--- a/src/test/java/land/oras/auth/RegistriesConfTest.java
+++ b/src/test/java/land/oras/auth/RegistriesConfTest.java
@@ -1,0 +1,70 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2026 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+
+/**
+ * Test class of {@link RegistriesConf}.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+class RegistriesConfTest {
+
+    @TempDir
+    private static Path homeDir;
+
+    // language=toml
+    public static final String HOME_REGISTRIES_CONF =
+            """
+            unqualified-search-registries = ["docker.io"]
+            """;
+
+    @BeforeAll
+    static void init() throws Exception {
+
+        // Write home registries.conf on the temp home directory
+        Files.createDirectory(homeDir.resolve(".config"));
+        Files.createDirectory(homeDir.resolve(".config").resolve("containers"));
+        Files.writeString(
+                homeDir.resolve(".config").resolve("containers").resolve("registries.conf"), HOME_REGISTRIES_CONF);
+    }
+
+    @Test
+    void shouldReadUnqualifiedSearchRegistriesFromHome() throws Exception {
+        new EnvironmentVariables()
+                .set("HOME", homeDir.toAbsolutePath().toString())
+                .execute(() -> {
+                    RegistriesConf conf = RegistriesConf.newConf();
+                    assertNotNull(conf);
+                    assertEquals(1, conf.getUnqualifiedRegistries().size());
+                    assertEquals("docker.io", conf.getUnqualifiedRegistries().get(0));
+                });
+    }
+}

--- a/src/test/java/land/oras/utils/TomlUtilsTest.java
+++ b/src/test/java/land/oras/utils/TomlUtilsTest.java
@@ -1,0 +1,96 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2025 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import land.oras.exception.OrasException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+public class TomlUtilsTest {
+
+    /**
+     * Temporary dir
+     */
+    @TempDir(cleanup = CleanupMode.ON_SUCCESS)
+    private static Path dir;
+
+    @Test
+    void failToParseTomlString() {
+        assertThrows(OrasException.class, () -> TomlUtils.fromToml("not a toml", Object.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldParseToml() {
+        String tomlMap = """
+                key1 = "value1"
+                key2 = "value2"
+                """;
+        Map<String, String> map = TomlUtils.fromToml(tomlMap, Map.class);
+        assertNotNull(map);
+        assertEquals(2, map.size());
+        assertEquals("value1", map.get("key1"));
+        assertEquals("value2", map.get("key2"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldParseTomlFile() throws IOException {
+        String tomlMap = """
+                key1 = "value1"
+                key2 = "value2"
+                """;
+        Path tomlFile = dir.resolve("test.toml");
+        Files.writeString(tomlFile, tomlMap);
+        Map<String, String> map = TomlUtils.fromToml(tomlFile, Map.class);
+        assertNotNull(map);
+        assertEquals(2, map.size());
+        assertEquals("value1", map.get("key1"));
+        assertEquals("value2", map.get("key2"));
+    }
+
+    @Test
+    void shouldConvertToToml() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        String toml = TomlUtils.toToml(map);
+        assertNotNull(toml);
+        String expected = """
+            key1 = 'value1'
+            key2 = 'value2'
+            """;
+        assertEquals(expected, toml);
+    }
+}


### PR DESCRIPTION
### Description

Start implementation of registries.conf

Do not use any of config for now (Just log unqualified-search-registries for now)

### Testing done

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
