### PR TITLE
[release/0.2.x] Bump ch.qos.logback:logback-classic from 1.5.19 to 1.5.20 (#437)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <bcprov-jdk18on.version>1.82</bcprov-jdk18on.version>
 
     <!-- Test dependencies version -->
-    <logback.version>1.5.19</logback.version>
+    <logback.version>1.5.20</logback.version>
     <junit.version>6.0.0</junit.version>
     <testcontainer.version>1.21.3</testcontainer.version>
     <wiremock.version>3.13.1</wiremock.version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/0.2.x`:
 - [Bump ch.qos.logback:logback-classic from 1.5.19 to 1.5.20 (#437)](https://github.com/oras-project/oras-java/pull/437)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)