### PR TITLE
Overly permissive regular expression range for artifact type validation

### DIFF
--- a/src/main/java/land/oras/ArtifactType.java
+++ b/src/main/java/land/oras/ArtifactType.java
@@ -57,7 +57,7 @@ public class ArtifactType {
             return unknown();
         }
         // Must match https://datatracker.ietf.org/doc/html/rfc6838
-        if (!artifactType.matches("^[a-zA-Z0-9!#$&-^_]+/[a-zA-Z0-9!#$&-^_]+$")) {
+        if (!artifactType.matches("^[a-zA-Z0-9!#$%&'*+.^_`{|}~-]+/[a-zA-Z0-9!#$%&'*+.^_`{|}~-]+$")) {
             throw new OrasException("Invalid artifact type: %s".formatted(artifactType));
         }
         return new ArtifactType(artifactType);


### PR DESCRIPTION
Potential fix for [https://github.com/oras-project/oras-java/security/code-scanning/38](https://github.com/oras-project/oras-java/security/code-scanning/38)

To fix this problem while maintaining correct (and standards-compliant) functionality, we should modify the regular expression to explicitly list all valid characters allowed in the media type "token" as defined by RFC6838/RFC2045. The RFC specifies the allowed characters for `token` as:  
`[A-Za-z0-9!#$%&'*+.^_`{}|~-]`  
That is, only a handful of ASCII symbols, alphanumerics, and the specified specials—not a broad range. The dash (`-`) should be either at the start or end of the character class to be literal, and special characters like `^` do *not* need to be included unless intended.  
Edit only line 60 (the regex) in `ArtifactType.java` accordingly. No new imports or helpers are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
