### PR TITLE
Refactor: Introduce CopyOptions class to replace boolean flag

### DIFF
--- a/C/oci-layout
+++ b/C/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0","repositories":{"repositories":["C"]}}

--- a/src/main/java/land/oras/CopyOptions.java
+++ b/src/main/java/land/oras/CopyOptions.java
@@ -1,0 +1,30 @@
+package land.oras;
+
+/**
+ * Options for the copy operation.
+ */
+public class CopyOptions {
+
+    /**
+     * Whether to copy referrers recursively.
+     */
+    private boolean recursive;
+
+    // TODO: In the future, we will add 'depth' and 'filter' here!
+
+    /**
+     * Constructor
+     * @param recursive true to copy referrers, false otherwise
+     */
+    public CopyOptions(boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    /**
+     * Gets the recursive setting.
+     * @return true if recursive
+     */
+    public boolean isRecursive() {
+        return recursive;
+    }
+}

--- a/src/main/java/land/oras/CopyUtils.java
+++ b/src/main/java/land/oras/CopyUtils.java
@@ -44,13 +44,32 @@ public final class CopyUtils {
         // Utils class
     }
 
+
+    /**
+     * Copy a container from source to target (Old Method - Backward Compatibility).
+     * @param source The source OCI
+     * @param sourceRef The source reference
+     * @param target The target OCI
+     * @param targetRef The target reference
+     * @param recursive Whether to copy referrers recursively
+     */
+    public static <SourceRefType extends Ref<@NonNull SourceRefType>, TargetRefType extends Ref<@NonNull TargetRefType>>
+    void copy(
+            OCI<SourceRefType> source,
+            SourceRefType sourceRef,
+            OCI<TargetRefType> target,
+            TargetRefType targetRef,
+            boolean recursive) {
+        // This converts the old boolean into your new class!
+        copy(source, sourceRef, target, targetRef, new CopyOptions(recursive));
+    }
     /**
      * Copy a container from source to target.
      * @param source The source OCI
      * @param sourceRef The source reference
      * @param target The target OCI
      * @param targetRef The target reference
-     * @param recursive Whether to copy referrers recursively
+     * @param options The copy options
      * @param <SourceRefType> The source reference type
      * @param <TargetRefType> The target reference type
      */
@@ -60,7 +79,7 @@ public final class CopyUtils {
                     SourceRefType sourceRef,
                     OCI<TargetRefType> target,
                     TargetRefType targetRef,
-                    boolean recursive) {
+                    CopyOptions options) {
 
         try {
 
@@ -94,12 +113,12 @@ public final class CopyUtils {
                 // Push the manifest
                 target.pushManifest(targetRef.withDigest(tag), manifest);
 
-                if (recursive) {
+                if (options.isRecursive()) {
                     LOG.debug("Recursively copy referrers");
                     Referrers referrers = source.getReferrers(sourceRef.withDigest(manifestDigest), null);
                     for (ManifestDescriptor referer : referrers.getManifests()) {
                         LOG.info("Copy reference {}", referer.getDigest());
-                        copy(source, sourceRef.withDigest(referer.getDigest()), target, targetRef, recursive);
+                        copy(source, sourceRef.withDigest(referer.getDigest()), target, targetRef, options);
                     }
                 }
 


### PR DESCRIPTION
### Description
Currently, `CopyUtils.copy()` uses a simple `boolean recursive` flag. This limits the ability to extend copy behavior in the future (e.g., setting depth, filtering referrers).

This PR refactors the `boolean` into a `CopyOptions` class. 
- It introduces `CopyOptions` with a `recursive` field.
- It updates `CopyUtils` to use this new options object.
- It maintains backward compatibility by keeping the original `copy(..., boolean recursive)` method as a wrapper.

### Related Issue
This addresses the need for more granular control over copy operations, similar to the Go SDK's `ExtendedCopyOptions`.

### Testing done
- [x] Verified that the code compiles.
- [x] Verified that existing tests pass (backward compatibility maintained).

### Submitter checklist
- [x] I have read and understood the CONTRIBUTING guide.
- [x] I have run `mvn spotless:apply`