### PR TITLE
Support access_token during login and reduce calls to auth store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ target/
 
 # IDEs
 .idea/
+*.iml
 
 # When testing JSON files
 *.json

--- a/src/main/java/land/oras/auth/HttpClient.java
+++ b/src/main/java/land/oras/auth/HttpClient.java
@@ -461,10 +461,11 @@ public final class HttpClient {
             LOG.debug("New scopes: {}", newScopes.getScopes());
 
             // Add authentication header if any
-            if (authProvider.getAuthHeader(containerRef) != null
+            var authHeader = authProvider.getAuthHeader(containerRef);
+            if (authHeader != null
                     && !authProvider.getAuthScheme().equals(AuthScheme.NONE)
                     && includeAuthHeader) {
-                builder = builder.header(Const.AUTHORIZATION_HEADER, authProvider.getAuthHeader(containerRef));
+                builder = builder.header(Const.AUTHORIZATION_HEADER, authHeader);
             }
             headers.forEach(builder::header);
 
@@ -524,8 +525,16 @@ public final class HttpClient {
                         token.expires_in(),
                         token.issued_at().plusSeconds(token.expires_in()));
             }
+            String bearerToken = token.token();
+            if (bearerToken == null) {
+                // Docker registry auth spec allows either token or auth_token (or both if they are the same)
+                bearerToken = token.access_token();
+            }
+            if (bearerToken == null) {
+                throw new OrasException("No Bearer token received");
+            }
             try {
-                builder = builder.setHeader(Const.AUTHORIZATION_HEADER, "Bearer " + token.token());
+                builder = builder.setHeader(Const.AUTHORIZATION_HEADER, "Bearer " + bearerToken);
                 HttpResponse<T> newResponse = client.send(builder.build(), handler);
 
                 // Follow redirect


### PR DESCRIPTION
<!--
 DO NOT DELETE

 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 -->

### Description
I ran into an issue while trying to use the client against our internal registry since it uses a different ([but allowed](https://docs.docker.com/reference/api/registry/auth/#token-response-fields)) token response field. As I was debugging I also noticed that the repeated calls to the auth store can actually reduce performance because it delegates to the binary locally multiple times so I just added a fix for that as well.
  
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done
I did not add tests at this point because the current behavior is not tested and I would prefer to make sure I can get the library to work before investing a lot of time in setting up complex testing using wiremock or refactoring significantly.


<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist
- [X] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [ ] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
