### PR TITLE
Implement test for ECR multi-arch image and fix possible content length missing

### DIFF
--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -579,10 +579,17 @@ public final class Registry extends OCI<ContainerRef> {
     @Override
     public Descriptor getDescriptor(ContainerRef containerRef) {
         HttpClient.ResponseWrapper<String> response = getManifestResponse(containerRef);
+        logResponse(response);
         handleError(response);
         String size = response.headers().get(Const.CONTENT_LENGTH_HEADER.toLowerCase());
         String contentType = response.headers().get(Const.CONTENT_TYPE_HEADER.toLowerCase());
-        return Descriptor.of(validateDockerContentDigest(response), Long.parseLong(size), contentType)
+        return Descriptor.of(
+                        validateDockerContentDigest(response),
+                        Long.parseLong(
+                                size == null
+                                        ? String.valueOf(response.response().length())
+                                        : size),
+                        contentType)
                 .withJson(response.response());
     }
 

--- a/src/test/java/land/oras/PublicECRITCase.java
+++ b/src/test/java/land/oras/PublicECRITCase.java
@@ -1,0 +1,46 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2025 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class PublicECRITCase {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @Disabled("Failing until #514 is fixed")
+    void shouldPullAnonymousIndex() {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse("public.ecr.aws/docker/library/alpine:latest");
+        Index index = registry.getIndex(containerRef1);
+        assertNotNull(index);
+    }
+}


### PR DESCRIPTION
Only partial fix for https://github.com/oras-project/oras-java/issues/514

### Description

Add test for public ECR public registry (failing for now) to demonstrate issue https://github.com/oras-project/oras-java/issues/514

Fix possible null content length that might not be present on reponse

### Testing done

mvn clean install

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
