### PR TITLE
Compute digest index and avoid `Docker-Content-Digest` when missing

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,2 +1,2 @@
-java=17.0.14-tem
+java=17.0.18-tem
 maven=3.9.12

--- a/src/main/java/land/oras/ManifestDescriptor.java
+++ b/src/main/java/land/oras/ManifestDescriptor.java
@@ -188,14 +188,24 @@ public final class ManifestDescriptor {
      * @return The subject
      */
     public static ManifestDescriptor of(Descriptor descriptor) {
-        Objects.requireNonNull(descriptor.getDigest());
+        return of(descriptor, descriptor.getDigest());
+    }
+
+    /**
+     * Create a manifest descriptor with the given digest
+     * @param descriptor The descriptor
+     * @param digest The digest
+     * @return The subject
+     */
+    public static ManifestDescriptor of(Descriptor descriptor, @Nullable String digest) {
         Objects.requireNonNull(descriptor.getSize());
+        Objects.requireNonNull(digest);
         return new ManifestDescriptor(
                 descriptor.getArtifactType() != null
                         ? descriptor.getArtifactType().getMediaType()
                         : null,
                 descriptor.getMediaType(),
-                descriptor.getDigest(),
+                digest,
                 descriptor.getSize(),
                 null,
                 descriptor.getAnnotations());

--- a/src/test/java/land/oras/PublicECRITCase.java
+++ b/src/test/java/land/oras/PublicECRITCase.java
@@ -22,25 +22,26 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.nio.file.Path;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
 class PublicECRITCase {
 
-    @TempDir
-    Path tempDir;
-
     @Test
-    @Disabled("Failing until #514 is fixed")
     void shouldPullAnonymousIndex() {
+
+        // Via tag
         Registry registry = Registry.builder().build();
         ContainerRef containerRef1 = ContainerRef.parse("public.ecr.aws/docker/library/alpine:latest");
         Index index = registry.getIndex(containerRef1);
         assertNotNull(index);
+
+        // Via digest
+        ContainerRef containerRef2 = ContainerRef.parse(
+                "public.ecr.aws/docker/library/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659");
+        Index index2 = registry.getIndex(containerRef2);
+        assertNotNull(index2);
     }
 }


### PR DESCRIPTION
Should fix https://github.com/oras-project/oras-java/issues/514

### Description

Compute digest index and avoid rely on Docker-Content-Digest

### Testing done

Implemented IT tests with `public.ecr.aws` 

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
