### PR TITLE
Avoid log binary response

### DIFF
--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -734,9 +734,13 @@ public final class Registry extends OCI<ContainerRef> {
     private void logResponse(HttpClient.ResponseWrapper<?> response) {
         LOG.debug("Status Code: {}", response.statusCode());
         LOG.debug("Headers: {}", response.headers());
+        String contentType = response.headers().get(Const.CONTENT_TYPE_HEADER.toLowerCase());
+        boolean isBinaryResponse = contentType != null && contentType.contains("octet-stream");
         // Only log non-binary responses
-        if (response.response() instanceof String) {
+        if (response.response() instanceof String && !isBinaryResponse) {
             LOG.debug("Response: {}", response.response());
+        } else {
+            LOG.debug("Not logging binary response of content type: {}", contentType);
         }
     }
 

--- a/src/main/java/land/oras/auth/HttpClient.java
+++ b/src/main/java/land/oras/auth/HttpClient.java
@@ -391,9 +391,9 @@ public final class HttpClient {
                 "Response: {}",
                 responseWrapper
                         .response()
-                        .replaceAll("\"token\"\\s*:\\s*\"([A-Za-z0-9\\-_\\.]+)\"", "\"token\":\"<redacted>\"")
+                        .replaceAll("\"token\"\\s*:\\s*\"([A-Za-z0-9\\-_\\.=]+)\"", "\"token\":\"<redacted>\"")
                         .replaceAll(
-                                "\"access_token\"\\s*:\\s*\"([A-Za-z0-9\\-_\\.]+)\"",
+                                "\"access_token\"\\s*:\\s*\"([A-Za-z0-9\\-_\\.=]+)\"",
                                 "\"access_token\":\"<redacted>\""));
         LOG.debug(
                 "Headers: {}",

--- a/src/test/java/land/oras/PublicAzureCRITCase.java
+++ b/src/test/java/land/oras/PublicAzureCRITCase.java
@@ -22,12 +22,18 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
 class PublicAzureCRITCase {
+
+    @TempDir
+    private Path tempDir;
 
     @Test
     void shouldPullAnonymousIndex() {
@@ -56,5 +62,16 @@ class PublicAzureCRITCase {
                 "mcr.microsoft.com/azurelinux/busybox@sha256:ec5adfc87f57633da1feedb2361c06374020ab9c99d4a14b19319e57284b6656");
         Manifest manifest1 = registry.getManifest(containerRef1);
         assertNotNull(manifest1);
+    }
+
+    @Test
+    void shouldPullOneBlob() throws IOException {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse(
+                "mcr.microsoft.com/azurelinux/busybox@sha256:ec5adfc87f57633da1feedb2361c06374020ab9c99d4a14b19319e57284b6656");
+        Manifest manifest = registry.getManifest(containerRef1);
+        Layer oneLayer = manifest.getLayers().get(0);
+        registry.fetchBlob(containerRef1.withDigest(oneLayer.getDigest()), tempDir.resolve("my-blob"));
+        assertNotNull(tempDir.resolve("my-blob"));
     }
 }

--- a/src/test/java/land/oras/QuayIoITCase.java
+++ b/src/test/java/land/oras/QuayIoITCase.java
@@ -22,15 +22,41 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class QuayIoITCase {
 
+    @TempDir
+    private Path tempDir;
+
     @Test
-    void shouldPull() {
+    void shouldPullIndex() {
         Registry registry = Registry.builder().build();
         ContainerRef containerRef1 = ContainerRef.parse("quay.io/openshift/origin-cli:latest");
         Index index = registry.getIndex(containerRef1);
         assertNotNull(index);
+    }
+
+    @Test
+    void shouldPullManifest() {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse(
+                "quay.io/openshift/origin-cli@sha256:58b3680e6f8141829412f3010477ed84ebc73da65665dcde988e0b2a1276ae1f");
+        Manifest manifest = registry.getManifest(containerRef1);
+        assertNotNull(manifest);
+    }
+
+    @Test
+    void shouldPullOneBlob() throws IOException {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse(
+                "quay.io/openshift/origin-cli@sha256:58b3680e6f8141829412f3010477ed84ebc73da65665dcde988e0b2a1276ae1f");
+        Manifest manifest = registry.getManifest(containerRef1);
+        Layer oneLayer = manifest.getLayers().get(0);
+        registry.fetchBlob(containerRef1.withDigest(oneLayer.getDigest()), tempDir.resolve("my-blob"));
+        assertNotNull(tempDir.resolve("my-blob"));
     }
 }


### PR DESCRIPTION
### Description

Avoid log binary response

### Testing done

mvn clean install

And check the logs for 

Not logging binary response of content type: application/octet-stream

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
