### PR TITLE
Avoid HEAD request before getting blobs

### DIFF
--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -354,6 +354,7 @@ public final class Registry extends OCI<ContainerRef> {
     public Layer pushBlob(ContainerRef containerRef, Path blob, Map<String, String> annotations) {
         String digest = containerRef.getAlgorithm().digest(blob);
         LOG.debug("Digest: {}", digest);
+        // This migh not works with registries performing HEAD request
         if (hasBlob(containerRef.withDigest(digest))) {
             LOG.info("Blob already exists: {}", digest);
             return Layer.fromFile(blob, containerRef.getAlgorithm()).withAnnotations(annotations);
@@ -491,9 +492,6 @@ public final class Registry extends OCI<ContainerRef> {
      */
     @Override
     public byte[] getBlob(ContainerRef containerRef) {
-        if (!hasBlob(containerRef)) {
-            throw new OrasException(new HttpClient.ResponseWrapper<>("", 404, Map.of()));
-        }
         URI uri = URI.create(
                 "%s://%s".formatted(getScheme(), containerRef.forRegistry(this).getBlobsPath(this)));
         HttpClient.ResponseWrapper<String> response = client.get(
@@ -510,9 +508,6 @@ public final class Registry extends OCI<ContainerRef> {
 
     @Override
     public void fetchBlob(ContainerRef containerRef, Path path) {
-        if (!hasBlob(containerRef)) {
-            throw new OrasException(new HttpClient.ResponseWrapper<>("", 404, Map.of()));
-        }
         URI uri = URI.create(
                 "%s://%s".formatted(getScheme(), containerRef.forRegistry(this).getBlobsPath(this)));
         HttpClient.ResponseWrapper<Path> response = client.download(
@@ -528,9 +523,6 @@ public final class Registry extends OCI<ContainerRef> {
 
     @Override
     public InputStream fetchBlob(ContainerRef containerRef) {
-        if (!hasBlob(containerRef)) {
-            throw new OrasException(new HttpClient.ResponseWrapper<>("", 404, Map.of()));
-        }
         URI uri = URI.create(
                 "%s://%s".formatted(getScheme(), containerRef.forRegistry(this).getBlobsPath(this)));
         HttpClient.ResponseWrapper<InputStream> response = client.download(

--- a/src/test/java/land/oras/PublicECRITCase.java
+++ b/src/test/java/land/oras/PublicECRITCase.java
@@ -22,11 +22,12 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
+@Execution(ExecutionMode.SAME_THREAD) // Avoid 429 Too Many Requests for unauthenticated requests to public ECR
 class PublicECRITCase {
 
     @Test
@@ -43,5 +44,23 @@ class PublicECRITCase {
                 "public.ecr.aws/docker/library/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659");
         Index index2 = registry.getIndex(containerRef2);
         assertNotNull(index2);
+    }
+
+    @Test
+    @Disabled("https://github.com/oras-project/oras-java/issues/522")
+    void shouldPullManifest() {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef = ContainerRef.parse(
+                "public.ecr.aws/docker/library/alpine@sha256:59855d3dceb3ae53991193bd03301e082b2a7faa56a514b03527ae0ec2ce3a95");
+        Manifest manifest = registry.getManifest(containerRef);
+        assertNotNull(manifest);
+    }
+
+    @Test
+    void shouldPullLayer() {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef = ContainerRef.parse(
+                "public.ecr.aws/docker/library/alpine@sha256:589002ba0eaed121a1dbf42f6648f29e5be55d5c8a6ee0f8eaa0285cc21ac153");
+        registry.getBlob(containerRef);
     }
 }


### PR DESCRIPTION
### Description

Reduce HTTP request when getting blobs

Also some registries like ECR doesn't support well HEAD https://github.com/oras-project/oras-java/issues/522#issuecomment-3861865522

### Testing done

mvn clean install

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
