### PR TITLE
Do not rely on Docker-Content-Digest when getting manifests

### DIFF
--- a/src/test/java/land/oras/GitHubContainerRegistryITCase.java
+++ b/src/test/java/land/oras/GitHubContainerRegistryITCase.java
@@ -44,6 +44,15 @@ class GitHubContainerRegistryITCase {
     }
 
     @Test
+    void shouldPUllManifest() {
+        Registry registry = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse(
+                "ghcr.io/oras-project/oras@sha256:fd4c818e80ea594cbd39ca47dc05067c8c5690c4eee6c8aee48c508290a5a0c0");
+        Manifest manifest = registry.getManifest(containerRef1);
+        assertNotNull(manifest);
+    }
+
+    @Test
     void shouldPullOneBlob() throws IOException {
         Registry registry = Registry.builder().build();
         ContainerRef containerRef1 = ContainerRef.parse("ghcr.io/oras-project/oras:main");

--- a/src/test/java/land/oras/HarborS3ITCase.java
+++ b/src/test/java/land/oras/HarborS3ITCase.java
@@ -29,6 +29,11 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+/**
+ * Test disabled due to authentication
+ * mkdir lib && touch lib/a
+ * oras push demo.goharbor.io/oras/lib:foo lib
+ */
 @Execution(ExecutionMode.CONCURRENT)
 class HarborS3ITCase {
 
@@ -36,7 +41,16 @@ class HarborS3ITCase {
     Path tempDir;
 
     @Test
-    @Disabled("Only to test with demo Harbor S3 instance")
+    @Disabled("Only to test with demo Harbor demo instance")
+    void shouldGetManifest() {
+        Registry registry = Registry.builder().defaults().build();
+        ContainerRef containerRef1 = ContainerRef.parse("demo.goharbor.io/oras/lib:foo");
+        Manifest manifest = registry.getManifest(containerRef1);
+        assertNotNull(manifest);
+    }
+
+    @Test
+    @Disabled("Only to test with demo Harbor demo instance")
     void shouldPullOneBlob() {
         Registry registry = Registry.builder().defaults().build();
         ContainerRef containerRef1 = ContainerRef.parse("demo.goharbor.io/oras/lib:foo");

--- a/src/test/java/land/oras/PublicECRITCase.java
+++ b/src/test/java/land/oras/PublicECRITCase.java
@@ -22,7 +22,6 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -47,13 +46,20 @@ class PublicECRITCase {
     }
 
     @Test
-    @Disabled("https://github.com/oras-project/oras-java/issues/522")
     void shouldPullManifest() {
-        Registry registry = Registry.builder().build();
-        ContainerRef containerRef = ContainerRef.parse(
+
+        // Via tag
+        Registry registry1 = Registry.builder().build();
+        ContainerRef containerRef1 = ContainerRef.parse("public.ecr.aws/bitnami/contour-operator:latest");
+        Manifest manifest1 = registry1.getManifest(containerRef1);
+        assertNotNull(manifest1);
+
+        // Via digest
+        Registry registry2 = Registry.builder().build();
+        ContainerRef containerRef2 = ContainerRef.parse(
                 "public.ecr.aws/docker/library/alpine@sha256:59855d3dceb3ae53991193bd03301e082b2a7faa56a514b03527ae0ec2ce3a95");
-        Manifest manifest = registry.getManifest(containerRef);
-        assertNotNull(manifest);
+        Manifest manifest2 = registry2.getManifest(containerRef2);
+        assertNotNull(manifest2);
     }
 
     @Test


### PR DESCRIPTION
### Description

Fix https://github.com/oras-project/oras-java/issues/522

### Testing done

mvn clean install and enable again test

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
