### PR TITLE
Support for alias in registries.conf

### DIFF
--- a/src/test/java/land/oras/ContainerRefTest.java
+++ b/src/test/java/land/oras/ContainerRefTest.java
@@ -71,6 +71,30 @@ class ContainerRefTest {
     }
 
     @Test
+    void shouldDetermineFromAlias() throws Exception {
+
+        // language=toml
+        String config =
+                """
+            [aliases]
+            "my-library/my-namespace"="localhost/test"
+            "my-library"="localhost/test2"
+            """;
+
+        Files.writeString(homeDir.resolve(".config").resolve("containers").resolve("registries.conf"), config);
+
+        new EnvironmentVariables()
+                .set("HOME", homeDir.toAbsolutePath().toString())
+                .execute(() -> {
+                    Registry registry = Registry.builder().defaults().build();
+                    ContainerRef unqualifiedRef = ContainerRef.parse("my-library/my-namespace");
+                    assertEquals("localhost/test", unqualifiedRef.getEffectiveRegistry(registry));
+                    ContainerRef unqualifiedRef2 = ContainerRef.parse("my-library");
+                    assertEquals("localhost/test2", unqualifiedRef2.getEffectiveRegistry(registry));
+                });
+    }
+
+    @Test
     void shouldDetermineEffectiveRegistry() throws Exception {
 
         // Use from container ref

--- a/src/test/java/land/oras/auth/RegistriesConfTest.java
+++ b/src/test/java/land/oras/auth/RegistriesConfTest.java
@@ -44,6 +44,9 @@ class RegistriesConfTest {
     public static final String HOME_REGISTRIES_CONF =
             """
             unqualified-search-registries = ["docker.io"]
+
+            [aliases]
+            "alpine"="docker.io/library/alpine"
             """;
 
     @BeforeAll
@@ -54,6 +57,19 @@ class RegistriesConfTest {
         Files.createDirectory(homeDir.resolve(".config").resolve("containers"));
         Files.writeString(
                 homeDir.resolve(".config").resolve("containers").resolve("registries.conf"), HOME_REGISTRIES_CONF);
+    }
+
+    @Test
+    void shouldReadAlias() throws Exception {
+        new EnvironmentVariables()
+                .set("HOME", homeDir.toAbsolutePath().toString())
+                .execute(() -> {
+                    RegistriesConf conf = RegistriesConf.newConf();
+                    assertNotNull(conf);
+                    assertEquals(1, conf.getAliases().size());
+                    assertEquals("docker.io/library/alpine", conf.getAliases().get("alpine"));
+                    assertTrue(conf.hasAlias("alpine"));
+                });
     }
 
     @Test


### PR DESCRIPTION
### Description

Support for alias in registries.conf

### Testing done

Implemented tests. 

Will check coverage on this PR

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
