### PR TITLE
Ensure HTTP status code is not lost when catching exception

### DIFF
--- a/src/main/java/land/oras/ContainerRef.java
+++ b/src/main/java/land/oras/ContainerRef.java
@@ -423,7 +423,7 @@ public final class ContainerRef extends Ref<ContainerRef> {
         String effectiveRegistry = getEffectiveRegistry(registry);
         ContainerRef effectiveRef = forRegistry(effectiveRegistry);
         if (registry.getRegistriesConf().isInsecure(effectiveRef)) {
-            LOG.info(
+            LOG.debug(
                     "Access to container reference {} is insecure by location configuration for registry {}",
                     this,
                     effectiveRegistry);
@@ -474,10 +474,10 @@ public final class ContainerRef extends Ref<ContainerRef> {
             if (registry.getRegistry() == null && registry.getRegistriesConf().hasAlias(key)) {
                 String newLocation = registry.getRegistriesConf().getAliases().get(key);
                 String newRefString = "%s:%s".formatted(newLocation, tag);
-                LOG.info("Using {} as an alias to {}", key, newRefString);
+                LOG.debug("Using {} as an alias to {}", key, newRefString);
                 return ContainerRef.parse(newRefString);
             }
-            LOG.info(
+            LOG.debug(
                     "The container reference {} was created without a registry. Will try to resolve using unqualified-search-registries in order",
                     this);
             return new ContainerRef(

--- a/src/main/java/land/oras/exception/OrasException.java
+++ b/src/main/java/land/oras/exception/OrasException.java
@@ -72,6 +72,16 @@ public class OrasException extends RuntimeException {
 
     /**
      * Constructor
+     * @param statusCode The status code
+     * @param message The message
+     */
+    public OrasException(int statusCode, String message) {
+        this(message);
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Constructor
      * @param message The message
      * @param cause The cause
      */

--- a/src/test/java/land/oras/GitHubContainerRegistryITCase.java
+++ b/src/test/java/land/oras/GitHubContainerRegistryITCase.java
@@ -22,7 +22,6 @@ package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import land.oras.utils.ArchiveUtils;
 import land.oras.utils.Const;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 @Execution(ExecutionMode.CONCURRENT)
 class GitHubContainerRegistryITCase {
@@ -59,18 +57,14 @@ class GitHubContainerRegistryITCase {
                 """;
 
         // Setup
-        Files.createDirectory(homeDir.resolve(".config"));
-        Files.createDirectory(homeDir.resolve(".config").resolve("containers"));
-        Files.writeString(homeDir.resolve(".config").resolve("containers").resolve("registries.conf"), config);
+        TestUtils.createRegistriesConfFile(tempDir, config);
 
-        new EnvironmentVariables()
-                .set("HOME", homeDir.toAbsolutePath().toString())
-                .execute(() -> {
-                    Registry registry = Registry.builder().defaults().build();
-                    ContainerRef containerRef1 = ContainerRef.parse("oras:main");
-                    Index index = registry.getIndex(containerRef1);
-                    assertNotNull(index);
-                });
+        TestUtils.withHome(homeDir, () -> {
+            Registry registry = Registry.builder().defaults().build();
+            ContainerRef containerRef1 = ContainerRef.parse("oras:main");
+            Index index = registry.getIndex(containerRef1);
+            assertNotNull(index);
+        });
     }
 
     @Test

--- a/src/test/java/land/oras/TestUtils.java
+++ b/src/test/java/land/oras/TestUtils.java
@@ -1,0 +1,65 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2026 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+
+/**
+ * Several tests utils
+ */
+public final class TestUtils {
+
+    /**
+     * Create a registries.conf file in the given home directory with the given content.
+     * @param homeDir the home directory where the .config/containers/registries.conf file will be created
+     * @param content the content of the registries.conf file
+     */
+    public static void createRegistriesConfFile(Path homeDir, String content) {
+        try {
+            Files.createDirectory(homeDir.resolve(".config"));
+            Files.createDirectory(homeDir.resolve(".config").resolve("containers"));
+            Files.writeString(homeDir.resolve(".config").resolve("containers").resolve("registries.conf"), content);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Execute the given action with the HOME environment variable set to the given home directory.
+     * @param homeDir the home directory to set in the HOME environment variable
+     * @param action the action to execute with the HOME environment variable set
+     * @throws Exception if any exception occurs during the execution of the action
+     */
+    public static void withHome(Path homeDir, Runnable action) throws Exception, IOException {
+        new EnvironmentVariables()
+                .set("HOME", homeDir.toAbsolutePath().toString())
+                .execute(() -> {
+                    try {
+                        action.run();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+}

--- a/src/test/java/land/oras/auth/RegistriesConfTest.java
+++ b/src/test/java/land/oras/auth/RegistriesConfTest.java
@@ -22,14 +22,13 @@ package land.oras.auth;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
+import land.oras.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 /**
  * Test class of {@link RegistriesConf}.
@@ -50,37 +49,28 @@ class RegistriesConfTest {
             """;
 
     @BeforeAll
-    static void init() throws Exception {
-
-        // Write home registries.conf on the temp home directory
-        Files.createDirectory(homeDir.resolve(".config"));
-        Files.createDirectory(homeDir.resolve(".config").resolve("containers"));
-        Files.writeString(
-                homeDir.resolve(".config").resolve("containers").resolve("registries.conf"), HOME_REGISTRIES_CONF);
+    static void init() {
+        TestUtils.createRegistriesConfFile(homeDir, HOME_REGISTRIES_CONF);
     }
 
     @Test
     void shouldReadAlias() throws Exception {
-        new EnvironmentVariables()
-                .set("HOME", homeDir.toAbsolutePath().toString())
-                .execute(() -> {
-                    RegistriesConf conf = RegistriesConf.newConf();
-                    assertNotNull(conf);
-                    assertEquals(1, conf.getAliases().size());
-                    assertEquals("docker.io/library/alpine", conf.getAliases().get("alpine"));
-                    assertTrue(conf.hasAlias("alpine"));
-                });
+        TestUtils.withHome(homeDir, () -> {
+            RegistriesConf conf = RegistriesConf.newConf();
+            assertNotNull(conf);
+            assertEquals(1, conf.getAliases().size());
+            assertEquals("docker.io/library/alpine", conf.getAliases().get("alpine"));
+            assertTrue(conf.hasAlias("alpine"));
+        });
     }
 
     @Test
     void shouldReadUnqualifiedSearchRegistriesFromHome() throws Exception {
-        new EnvironmentVariables()
-                .set("HOME", homeDir.toAbsolutePath().toString())
-                .execute(() -> {
-                    RegistriesConf conf = RegistriesConf.newConf();
-                    assertNotNull(conf);
-                    assertEquals(1, conf.getUnqualifiedRegistries().size());
-                    assertEquals("docker.io", conf.getUnqualifiedRegistries().get(0));
-                });
+        TestUtils.withHome(homeDir, () -> {
+            RegistriesConf conf = RegistriesConf.newConf();
+            assertNotNull(conf);
+            assertEquals(1, conf.getUnqualifiedRegistries().size());
+            assertEquals("docker.io", conf.getUnqualifiedRegistries().get(0));
+        });
     }
 }


### PR DESCRIPTION
### Description

Ensure HTTP status code is not lost when catching exception

### Testing done

Added one test

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
