### PR TITLE
Optimize copy by passing stream with known size and digest

### DIFF
--- a/src/main/java/land/oras/ContainerRef.java
+++ b/src/main/java/land/oras/ContainerRef.java
@@ -326,6 +326,15 @@ public final class ContainerRef extends Ref<ContainerRef> {
     }
 
     /**
+     * Return the blobs upload URL for POST upload to get the upload location
+     * @param registry The registry
+     * @return The blobs upload URL
+     */
+    public String getBlobsUploadPath(Registry registry) {
+        return "%s/blobs/uploads/".formatted(getApiPrefix(registry));
+    }
+
+    /**
      * Return the blobs URL
      * @param registry The registry
      * @return The blobs URL

--- a/src/main/java/land/oras/OCI.java
+++ b/src/main/java/land/oras/OCI.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import land.oras.exception.OrasException;
 import land.oras.utils.ArchiveUtils;
 import land.oras.utils.Const;
@@ -374,6 +375,16 @@ public abstract sealed class OCI<T extends Ref<@NonNull T>> permits Registry, OC
      * @return The layer
      */
     public abstract Layer pushBlob(T ref, Path blob, Map<String, String> annotations);
+
+    /**
+     * Push a blob from input stream with known digest and size
+     * @param ref The container ref with digest
+     * @param size The size of the blob
+     * @param stream The input stream of the blob
+     * @param annotations The annotations
+     * @return The layer
+     */
+    public abstract Layer pushBlob(T ref, long size, Supplier<InputStream> stream, Map<String, String> annotations);
 
     /**
      * Push the blob for the given layer

--- a/src/main/java/land/oras/auth/HttpClient.java
+++ b/src/main/java/land/oras/auth/HttpClient.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -235,6 +236,35 @@ public final class HttpClient {
     }
 
     /**
+     * Upload from an input stream.
+     * @param uri The URI
+     * @param size The size of the input stream
+     * @param headers The headers
+     * @param stream The input stream
+     * @param scopes The scopes
+     * @param authProvider The authentication provider
+     * @return The response
+     */
+    public ResponseWrapper<String> upload(
+            URI uri,
+            long size,
+            Map<String, String> headers,
+            Supplier<InputStream> stream,
+            Scopes scopes,
+            AuthProvider authProvider) {
+        return executeRequest(
+                "PUT",
+                uri,
+                true,
+                headers,
+                new byte[0],
+                HttpResponse.BodyHandlers.ofString(),
+                HttpRequest.BodyPublishers.fromPublisher(HttpRequest.BodyPublishers.ofInputStream(stream), size),
+                scopes,
+                authProvider);
+    }
+
+    /**
      * Perform a HEAD request
      * @param uri The URI
      * @param headers The headers
@@ -296,7 +326,7 @@ public final class HttpClient {
                 headers,
                 body,
                 HttpResponse.BodyHandlers.ofString(),
-                HttpRequest.BodyPublishers.ofByteArray(body),
+                body.length == 0 ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofByteArray(body),
                 scopes,
                 authProvider);
     }

--- a/src/test/java/land/oras/ContainerRefTest.java
+++ b/src/test/java/land/oras/ContainerRefTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 class ContainerRefTest {
 
     @Test
+    @Execution(ExecutionMode.SAME_THREAD)
     void shouldReadRegistriesConfig(@TempDir Path homeDir) throws Exception {
         // language=toml
         String config =
@@ -77,6 +78,7 @@ class ContainerRefTest {
     }
 
     @Test
+    @Execution(ExecutionMode.SAME_THREAD)
     void shouldDetermineFromAlias(@TempDir Path homeDir) throws Exception {
 
         // language=toml
@@ -99,6 +101,7 @@ class ContainerRefTest {
     }
 
     @Test
+    @Execution(ExecutionMode.SAME_THREAD)
     void shouldRewriteAllSubdomainToLocalProxy(@TempDir Path homeDir) throws Exception {
 
         // language=toml
@@ -145,6 +148,7 @@ class ContainerRefTest {
     }
 
     @Test
+    @Execution(ExecutionMode.SAME_THREAD)
     void shouldDetermineEffectiveRegistry(@TempDir Path homeDir) throws Exception {
 
         // Use from container ref

--- a/src/test/java/land/oras/GitHubContainerRegistryITCase.java
+++ b/src/test/java/land/oras/GitHubContainerRegistryITCase.java
@@ -36,9 +36,6 @@ class GitHubContainerRegistryITCase {
     @TempDir
     Path tempDir;
 
-    @TempDir
-    private static Path homeDir;
-
     @Test
     void shouldPullIndex() {
         Registry registry = Registry.builder().build();
@@ -48,7 +45,8 @@ class GitHubContainerRegistryITCase {
     }
 
     @Test
-    void shouldPullIndexWithAlias() throws Exception {
+    @Execution(ExecutionMode.SAME_THREAD)
+    void shouldPullIndexWithAlias(@TempDir Path homeDir) throws Exception {
         // language=toml
         String config =
                 """
@@ -57,7 +55,7 @@ class GitHubContainerRegistryITCase {
                 """;
 
         // Setup
-        TestUtils.createRegistriesConfFile(tempDir, config);
+        TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
             Registry registry = Registry.builder().defaults().build();

--- a/src/test/java/land/oras/OCILayoutTest.java
+++ b/src/test/java/land/oras/OCILayoutTest.java
@@ -619,6 +619,30 @@ class OCILayoutTest {
     }
 
     @Test
+    void shouldFailToPushBlobViaStreamWithoutDigest() {
+        Path path = layoutPath.resolve("shouldFailToPushBlobViaStreamWithoutDigest");
+        byte[] content = "hi".getBytes(StandardCharsets.UTF_8);
+        OCILayout ociLayout = OCILayout.Builder.builder().defaults(path).build();
+        LayoutRef layoutRef = LayoutRef.parse("test");
+        OrasException e = assertThrows(OrasException.class, () -> {
+            ociLayout.pushBlob(layoutRef, content.length, () -> InputStream.nullInputStream(), Map.of());
+        });
+        assertEquals("Digest is required to push blob to layout", e.getMessage());
+    }
+
+    @Test
+    void shouldFailToPushBlobViaStreamWithInvalidDigest() {
+        Path path = layoutPath.resolve("shouldFailToPushBlobViaStreamWithInvalidDigest");
+        byte[] content = "hi".getBytes(StandardCharsets.UTF_8);
+        OCILayout ociLayout = OCILayout.Builder.builder().defaults(path).build();
+        LayoutRef layoutRef = LayoutRef.parse("test:1234");
+        OrasException e = assertThrows(OrasException.class, () -> {
+            ociLayout.pushBlob(layoutRef, content.length, () -> InputStream.nullInputStream(), Map.of());
+        });
+        assertEquals("Unsupported digest: 1234", e.getMessage());
+    }
+
+    @Test
     void cannotPushBlobWithoutTagOrDigest() throws IOException {
 
         Path invalidBlobPushDir = layoutPath.resolve("shouldPushArtifact");

--- a/src/test/java/land/oras/PublicECRITCase.java
+++ b/src/test/java/land/oras/PublicECRITCase.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
-@Execution(ExecutionMode.SAME_THREAD) // Avoid 429 Too Many Requests for unauthenticated requests to public ECR
+@Execution(ExecutionMode.SAME_THREAD)
 class PublicECRITCase {
 
     @TempDir

--- a/src/test/java/land/oras/TestUtils.java
+++ b/src/test/java/land/oras/TestUtils.java
@@ -51,7 +51,7 @@ public final class TestUtils {
      * @param action the action to execute with the HOME environment variable set
      * @throws Exception if any exception occurs during the execution of the action
      */
-    public static void withHome(Path homeDir, Runnable action) throws Exception, IOException {
+    public static void withHome(Path homeDir, Runnable action) throws Exception {
         new EnvironmentVariables()
                 .set("HOME", homeDir.toAbsolutePath().toString())
                 .execute(() -> {

--- a/src/test/java/land/oras/auth/RegistriesConfTest.java
+++ b/src/test/java/land/oras/auth/RegistriesConfTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 /**
  * Test class of {@link RegistriesConf}.
  */
-@Execution(ExecutionMode.CONCURRENT)
+@Execution(ExecutionMode.SAME_THREAD)
 class RegistriesConfTest {
 
     @TempDir


### PR DESCRIPTION
Fix https://github.com/oras-project/oras-java/issues/508

### Description

Optimize copy pas passing stream with known size and digest

This add a new API on OCI parent class

```java
public Layer pushBlob(T ref, long size, Supplier<InputStream> stream, Map<String, String> annotations) {
```

### Testing done

Rely on automated tests

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
