### PR TITLE
When copy ensure to push all manifests before index

### DIFF
--- a/src/test/java/land/oras/DockerIoITCase.java
+++ b/src/test/java/land/oras/DockerIoITCase.java
@@ -23,16 +23,23 @@ package land.oras;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Path;
+import land.oras.utils.ZotUnsecureContainer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @Execution(ExecutionMode.CONCURRENT)
 class DockerIoITCase {
 
     @TempDir
     Path tempDir;
+
+    @Container
+    private final ZotUnsecureContainer unsecureRegistry = new ZotUnsecureContainer().withStartupAttempts(3);
 
     @Test
     void shouldPullAnonymousIndexFQDN() {
@@ -74,5 +81,25 @@ class DockerIoITCase {
                 containerRef1.forRegistry(effectiveRegistry).withDigest(oneLayer.getDigest()),
                 tempDir.resolve("my-blob"));
         assertNotNull(tempDir.resolve("my-blob"));
+    }
+
+    @Test
+    void shouldCopyTagToInternalRegistry() {
+
+        // Source registry
+        Registry sourceRegistry = Registry.Builder.builder().defaults().build();
+
+        // Copy to this internal registry
+        Registry targetRegistry = Registry.Builder.builder()
+                .defaults("myuser", "mypass")
+                .withInsecure(true)
+                .build();
+
+        ContainerRef containerSource = ContainerRef.parse("docker.io/library/alpine:latest");
+        ContainerRef containerTarget =
+                ContainerRef.parse("%s/docker/library/alpine:latest".formatted(unsecureRegistry.getRegistry()));
+
+        CopyUtils.copy(sourceRegistry, containerSource, targetRegistry, containerTarget, true);
+        assertTrue(targetRegistry.exists(containerTarget));
     }
 }

--- a/src/test/java/land/oras/OCILayoutTest.java
+++ b/src/test/java/land/oras/OCILayoutTest.java
@@ -948,7 +948,7 @@ class OCILayoutTest {
 
         // Check index and manifest are stored in index
         assertIndex(layoutPathIndex, index, 2);
-        assertIndex(layoutPathIndex, pushedManifest, 2, 1);
+        assertIndex(layoutPathIndex, pushedManifest, 2, 0);
 
         // Check manifest exists
         assertBlobExists(layoutPathIndex, pushedManifest.getDescriptor().getDigest());
@@ -983,7 +983,7 @@ class OCILayoutTest {
         // Check latest tag
         Index ociIndex = Index.fromPath(layoutPathIndex.resolve(Const.OCI_LAYOUT_INDEX));
         assertEquals(2, ociIndex.getManifests().size());
-        assertEquals("latest", ociIndex.getManifests().get(0).getAnnotations().get(Const.ANNOTATION_REF));
+        assertEquals("latest", ociIndex.getManifests().get(1).getAnnotations().get(Const.ANNOTATION_REF));
     }
 
     @Test
@@ -1048,7 +1048,8 @@ class OCILayoutTest {
         assertEquals(size, ociIndex.getManifests().size());
         assertEquals(Const.DEFAULT_INDEX_MEDIA_TYPE, ociIndex.getMediaType());
         assertEquals(
-                index.getDescriptor().getSize(), ociIndex.getManifests().get(0).getSize());
+                index.getDescriptor().getSize(),
+                ociIndex.getManifests().get(ociIndex.getManifests().size() - 1).getSize());
     }
 
     private void assertLayerExists(Path ociLayoutPath, Layer layer) {


### PR DESCRIPTION
### Description

When copy ensure to push all manifests before index

### Testing done

Added tests. Test was failing for alpine image copy. It now works to copy image to internal registry

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
