### PR TITLE
Only try to parse Error if we get JSON content type

### DIFF
--- a/src/main/java/land/oras/exception/OrasException.java
+++ b/src/main/java/land/oras/exception/OrasException.java
@@ -21,6 +21,7 @@
 package land.oras.exception;
 
 import land.oras.auth.HttpClient;
+import land.oras.utils.Const;
 import land.oras.utils.JsonUtils;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -62,9 +63,15 @@ public class OrasException extends RuntimeException {
      */
     public OrasException(HttpClient.ResponseWrapper<String> response) {
         this("Response code: " + response.statusCode());
+        String contentType = response.headers().getOrDefault(Const.CONTENT_TYPE_HEADER, "");
         try {
             this.statusCode = response.statusCode();
-            error = JsonUtils.fromJson(response.response(), Error.class);
+            if (contentType.contains(Const.DEFAULT_JSON_MEDIA_TYPE)) {
+                this.error = JsonUtils.fromJson(response.response(), Error.class);
+                LOG.debug("Parsed error response: {}", error);
+            } else {
+                LOG.debug("Response content type is not JSON, cannot parse error response");
+            }
         } catch (Exception e) {
             LOG.debug("Failed to parse error response", e);
         }

--- a/src/test/java/land/oras/exception/OrasExceptionTest.java
+++ b/src/test/java/land/oras/exception/OrasExceptionTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
 import land.oras.auth.HttpClient;
+import land.oras.utils.Const;
 import land.oras.utils.JsonUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -47,7 +48,9 @@ class OrasExceptionTest {
     @Test
     void shouldWrapResponse() {
         HttpClient.ResponseWrapper<String> response = new HttpClient.ResponseWrapper<>(
-                JsonUtils.toJson(new Error("5001", "foo", "the details")), 500, Map.of());
+                JsonUtils.toJson(new Error("5001", "foo", "the details")),
+                500,
+                Map.of(Const.CONTENT_TYPE_HEADER, Const.DEFAULT_JSON_MEDIA_TYPE));
         OrasException orasException = new OrasException(response);
 
         // Getters


### PR DESCRIPTION
### Description

Only try to parse Error if we get JSON content type.

Avoid populing the logs with JSON parse issue

### Testing done

None in particular

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
