### PR TITLE
Store resolve registry when probing descriptor and use it for copy operation

### DIFF
--- a/src/main/java/land/oras/Config.java
+++ b/src/main/java/land/oras/Config.java
@@ -66,6 +66,7 @@ public final class Config extends Descriptor {
                 mediaType,
                 annotations != null && !annotations.isEmpty() ? Map.copyOf(annotations) : null,
                 null,
+                null,
                 null);
         this.data = data;
     }
@@ -76,6 +77,7 @@ public final class Config extends Descriptor {
                 size,
                 mediaType,
                 !annotations.configAnnotations().isEmpty() ? Map.copyOf(annotations.configAnnotations()) : null,
+                null,
                 null,
                 null);
         this.data = data;

--- a/src/main/java/land/oras/ContainerRef.java
+++ b/src/main/java/land/oras/ContainerRef.java
@@ -472,6 +472,16 @@ public final class ContainerRef extends Ref<ContainerRef> {
         return this;
     }
 
+    @Override
+    public ContainerRef forTarget(String target) {
+        return forRegistry(target);
+    }
+
+    @Override
+    public String getTarget(OCI<ContainerRef> target) {
+        return getEffectiveRegistry((Registry) target);
+    }
+
     /**
      * Return a copy of reference for a registry other registry
      * @param registry The registry

--- a/src/main/java/land/oras/Descriptor.java
+++ b/src/main/java/land/oras/Descriptor.java
@@ -68,6 +68,11 @@ public sealed class Descriptor permits Config, Manifest, Layer, Index {
     protected String json;
 
     /**
+     * The registry
+     */
+    protected @Nullable String registry;
+
+    /**
      * Constructor
      * @param digest The digest
      * @param size The size
@@ -82,12 +87,14 @@ public sealed class Descriptor permits Config, Manifest, Layer, Index {
             String mediaType,
             Map<String, String> annotations,
             String artifactType,
+            String registry,
             String json) {
         this.digest = digest;
         this.size = size;
         this.mediaType = mediaType;
         this.annotations = annotations;
         this.artifactType = artifactType;
+        this.registry = registry;
         this.json = json;
     }
 
@@ -98,6 +105,15 @@ public sealed class Descriptor permits Config, Manifest, Layer, Index {
     @JsonIgnore
     public String getJson() {
         return json;
+    }
+
+    /**
+     * Return the resolved registry. Useful to avoid querying registry blobs when the registry is already resolved in the descriptor.
+     * @return The resolved registry or null if not resolved
+     */
+    @JsonIgnore
+    public @Nullable String getRegistry() {
+        return registry;
     }
 
     /**
@@ -179,6 +195,16 @@ public sealed class Descriptor permits Config, Manifest, Layer, Index {
     }
 
     /**
+     * Return same instance but with resolved registry
+     * @param registry The resolved registry
+     * @return The descriptor with resolved registry
+     */
+    protected Descriptor withRegistry(String registry) {
+        this.registry = registry;
+        return this;
+    }
+
+    /**
      * Return this manifest descriptor as a subject
      * @return The subject
      */
@@ -199,7 +225,7 @@ public sealed class Descriptor permits Config, Manifest, Layer, Index {
      */
     public static Descriptor of(
             String digest, Long size, String mediaType, Map<String, String> annotations, String artifactType) {
-        return new Descriptor(digest, size, mediaType, annotations, artifactType, null);
+        return new Descriptor(digest, size, mediaType, annotations, artifactType, null, null);
     }
 
     /**
@@ -210,7 +236,7 @@ public sealed class Descriptor permits Config, Manifest, Layer, Index {
      * @return The descriptor
      */
     public static Descriptor of(String digest, Long size, String mediaType) {
-        return new Descriptor(digest, size, mediaType, null, null, null);
+        return new Descriptor(digest, size, mediaType, null, null, null, null);
     }
 
     /**
@@ -220,7 +246,7 @@ public sealed class Descriptor permits Config, Manifest, Layer, Index {
      * @return The descriptor
      */
     public static Descriptor of(String digest, Long size) {
-        return new Descriptor(digest, size, Const.DEFAULT_DESCRIPTOR_MEDIA_TYPE, null, null, null);
+        return new Descriptor(digest, size, Const.DEFAULT_DESCRIPTOR_MEDIA_TYPE, null, null, null, null);
     }
 
     @Override

--- a/src/main/java/land/oras/Index.java
+++ b/src/main/java/land/oras/Index.java
@@ -70,7 +70,7 @@ public final class Index extends Descriptor implements Describable {
             @JsonProperty(Const.JSON_PROPERTY_MANIFESTS) List<ManifestDescriptor> manifests,
             @JsonProperty(Const.JSON_PROPERTY_ANNOTATIONS) Map<String, String> annotations,
             @JsonProperty(Const.JSON_PROPERTY_SUBJECT) Subject subject) {
-        this(schemaVersion, mediaType, artifactType, manifests, annotations, subject, null, null);
+        this(schemaVersion, mediaType, artifactType, manifests, annotations, subject, null, null, null);
     }
 
     private Index(
@@ -81,8 +81,9 @@ public final class Index extends Descriptor implements Describable {
             Map<String, String> annotations,
             Subject subject,
             ManifestDescriptor descriptor,
+            String registry,
             String json) {
-        super(null, null, mediaType, annotations, artifactType, json);
+        super(null, null, mediaType, annotations, artifactType, registry, json);
         this.schemaVersion = schemaVersion;
         this.descriptor = descriptor;
         this.subject = subject;
@@ -183,7 +184,8 @@ public final class Index extends Descriptor implements Describable {
             newManifests.add(ManifestDescriptor.fromJson(descriptor.toJson()));
         }
         newManifests.add(manifest);
-        return new Index(schemaVersion, mediaType, artifactType, newManifests, annotations, subject, descriptor, json);
+        return new Index(
+                schemaVersion, mediaType, artifactType, newManifests, annotations, subject, descriptor, registry, json);
     }
 
     @Override
@@ -209,7 +211,8 @@ public final class Index extends Descriptor implements Describable {
      * @return The manifest
      */
     public Index withDescriptor(ManifestDescriptor descriptor) {
-        return new Index(schemaVersion, mediaType, artifactType, manifests, annotations, subject, descriptor, json);
+        return new Index(
+                schemaVersion, mediaType, artifactType, manifests, annotations, subject, descriptor, registry, json);
     }
 
     /**
@@ -233,7 +236,8 @@ public final class Index extends Descriptor implements Describable {
      * @return The index
      */
     public Index withSubject(Subject subject) {
-        return new Index(schemaVersion, mediaType, artifactType, manifests, annotations, subject, descriptor, json);
+        return new Index(
+                schemaVersion, mediaType, artifactType, manifests, annotations, subject, descriptor, registry, json);
     }
 
     /**
@@ -260,7 +264,7 @@ public final class Index extends Descriptor implements Describable {
      * @return The index
      */
     public static Index fromManifests(List<ManifestDescriptor> descriptors) {
-        return new Index(2, Const.DEFAULT_INDEX_MEDIA_TYPE, null, descriptors, null, null, null, null);
+        return new Index(2, Const.DEFAULT_INDEX_MEDIA_TYPE, null, descriptors, null, null, null, null, null);
     }
 
     @Override

--- a/src/main/java/land/oras/Layer.java
+++ b/src/main/java/land/oras/Layer.java
@@ -68,7 +68,7 @@ public final class Layer extends Descriptor {
             @JsonProperty(Const.JSON_PROPERTY_SIZE) @Nullable Long size,
             @JsonProperty(Const.JSON_PROPERTY_DATA) @Nullable String data,
             @JsonProperty(Const.JSON_PROPERTY_ANNOTATIONS) @Nullable Map<String, String> annotations) {
-        super(digest, size, mediaType, annotations, null, null);
+        super(digest, size, mediaType, annotations, null, null, null);
         this.data = data;
         this.blobPath = null;
     }
@@ -81,7 +81,7 @@ public final class Layer extends Descriptor {
      * @param blobPath The path to the blob
      */
     private Layer(String mediaType, String digest, long size, Path blobPath, Map<String, String> annotations) {
-        super(digest, size, mediaType, annotations, null, null);
+        super(digest, size, mediaType, annotations, null, null, null);
         this.data = null;
         this.blobPath = blobPath;
     }

--- a/src/main/java/land/oras/LayoutRef.java
+++ b/src/main/java/land/oras/LayoutRef.java
@@ -155,6 +155,16 @@ public final class LayoutRef extends Ref<LayoutRef> {
     }
 
     @Override
+    public LayoutRef forTarget(String target) {
+        return new LayoutRef(Path.of(target), tag);
+    }
+
+    @Override
+    public String getTarget(OCI<LayoutRef> target) {
+        return folder.toString();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         LayoutRef layoutRef = (LayoutRef) o;

--- a/src/main/java/land/oras/Manifest.java
+++ b/src/main/java/land/oras/Manifest.java
@@ -84,6 +84,7 @@ public final class Manifest extends Descriptor implements Describable {
                 mediaType,
                 annotations != null && !annotations.isEmpty() ? Map.copyOf(annotations) : null,
                 artifactType,
+                null,
                 null);
         this.schemaVersion = schemaVersion;
         this.descriptor = null;
@@ -101,6 +102,7 @@ public final class Manifest extends Descriptor implements Describable {
             Subject subject,
             List<Layer> layers,
             Annotations annotations,
+            String registry,
             String json) {
         super(
                 null,
@@ -108,6 +110,7 @@ public final class Manifest extends Descriptor implements Describable {
                 mediaType,
                 Map.copyOf(annotations.manifestAnnotations()),
                 artifactType != null ? artifactType.getMediaType() : null,
+                registry,
                 json);
         this.schemaVersion = schemaVersion;
         this.descriptor = descriptor;
@@ -208,6 +211,7 @@ public final class Manifest extends Descriptor implements Describable {
                 subject,
                 layers,
                 Annotations.ofManifest(annotations),
+                registry,
                 json);
     }
 
@@ -226,6 +230,7 @@ public final class Manifest extends Descriptor implements Describable {
                 subject,
                 layers,
                 Annotations.ofManifest(annotations),
+                registry,
                 json);
     }
 
@@ -244,6 +249,7 @@ public final class Manifest extends Descriptor implements Describable {
                 subject,
                 layers,
                 Annotations.ofManifest(annotations),
+                registry,
                 json);
     }
 
@@ -262,6 +268,7 @@ public final class Manifest extends Descriptor implements Describable {
                 subject,
                 layers,
                 Annotations.ofManifest(annotations),
+                registry,
                 json);
     }
 
@@ -280,6 +287,7 @@ public final class Manifest extends Descriptor implements Describable {
                 subject,
                 layers,
                 Annotations.ofManifest(annotations),
+                registry,
                 json);
     }
 
@@ -298,6 +306,7 @@ public final class Manifest extends Descriptor implements Describable {
                 subject,
                 layers,
                 Annotations.ofManifest(annotations),
+                registry,
                 json);
     }
 
@@ -354,6 +363,7 @@ public final class Manifest extends Descriptor implements Describable {
                 null,
                 List.of(),
                 Annotations.empty(),
+                null,
                 null);
     }
 

--- a/src/main/java/land/oras/OCILayout.java
+++ b/src/main/java/land/oras/OCILayout.java
@@ -430,7 +430,7 @@ public final class OCILayout extends OCI<LayoutRef> {
     @Override
     public Descriptor probeDescriptor(LayoutRef ref) {
         // We should probably optimize to avoid reading the descriptor and only get its attributes (JSON path?)
-        return getDescriptor(ref).withJson(null);
+        return getDescriptor(ref).withRegistry(ref.getFolder().toString()).withJson(null);
     }
 
     private byte[] getDescriptorData(Descriptor descriptor) {

--- a/src/main/java/land/oras/Ref.java
+++ b/src/main/java/land/oras/Ref.java
@@ -70,4 +70,18 @@ public abstract sealed class Ref<T extends Ref<T>> permits ContainerRef, LayoutR
      * @return The repository
      */
     public abstract String getRepository();
+
+    /**
+     * Return a container ref for the target repository
+     * @param target The target repository
+     * @return The container ref
+     */
+    public abstract T forTarget(String target);
+
+    /**
+     * Get the target repository for the ref
+     * @param target The target repository
+     * @return The target repository
+     */
+    public abstract String getTarget(OCI<T> target);
 }


### PR DESCRIPTION
### Description

Store resolve registry when probing descriptor and use it for copy operation

### Testing done

Rely on existing tests

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
