### PR TITLE
Allow setting `short-name-mode` and set mode to `enforcing` by default (like podman / CRI-IO)

### DIFF
--- a/src/main/java/land/oras/ContainerRef.java
+++ b/src/main/java/land/oras/ContainerRef.java
@@ -531,6 +531,7 @@ public final class ContainerRef extends Ref<ContainerRef> {
         LOG.debug(
                 "Found registries in unqualified-search-registries: {}",
                 registry.getRegistriesConf().getUnqualifiedRegistries());
+        registry.getRegistriesConf().enforceShortNameMode();
         List<String> unqualifiedRegistries = registry.getRegistriesConf().getUnqualifiedRegistries();
         for (String searchRegistry : unqualifiedRegistries) {
             Registry targetRegistry = registry.copy(searchRegistry);

--- a/src/test/java/land/oras/auth/RegistryConfTest.java
+++ b/src/test/java/land/oras/auth/RegistryConfTest.java
@@ -20,6 +20,7 @@
 
 package land.oras.auth;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -62,6 +63,7 @@ class RegistryConfTest {
         RegistriesConf conf = new RegistriesConf(new RegistriesConf.Config(List.of(registry)));
         assertFalse(conf.isBlocked(ContainerRef.parse("localhost:5000/library/test:latest")));
         assertFalse(conf.isBlocked(ContainerRef.parse("localhost:5001/library/test:latest")));
+        assertDoesNotThrow(conf::enforceShortNameMode);
 
         // With blocked true
         registry = new RegistriesConf.RegistryConfig(null, "localhost:5000", true, null);
@@ -69,6 +71,7 @@ class RegistryConfTest {
         conf = new RegistriesConf(new RegistriesConf.Config(List.of(registry)));
         assertTrue(conf.isBlocked(ContainerRef.parse("localhost:5000/library/test:latest")));
         assertFalse(conf.isBlocked(ContainerRef.parse("localhost:5001/library/test:latest")));
+        assertDoesNotThrow(conf::enforceShortNameMode);
 
         // With insecure true
         registry = new RegistriesConf.RegistryConfig(null, "localhost:5000", null, true);
@@ -76,6 +79,7 @@ class RegistryConfTest {
         conf = new RegistriesConf(new RegistriesConf.Config(List.of(registry)));
         assertTrue(conf.isInsecure(ContainerRef.parse("localhost:5000/library/test:latest")));
         assertFalse(conf.isInsecure(ContainerRef.parse("localhost:5001/library/test:latest")));
+        assertDoesNotThrow(conf::enforceShortNameMode);
 
         // With blocked false
         registry = new RegistriesConf.RegistryConfig(null, "localhost:5000", false, null);
@@ -83,6 +87,7 @@ class RegistryConfTest {
         conf = new RegistriesConf(new RegistriesConf.Config(List.of(registry)));
         assertFalse(conf.isBlocked(ContainerRef.parse("localhost:5000/library/test:latest")));
         assertFalse(conf.isBlocked(ContainerRef.parse("localhost:5001/library/test:latest")));
+        assertDoesNotThrow(conf::enforceShortNameMode);
 
         // With insecure false
         registry = new RegistriesConf.RegistryConfig(null, "localhost:5000", null, false);
@@ -90,6 +95,7 @@ class RegistryConfTest {
         conf = new RegistriesConf(new RegistriesConf.Config(List.of(registry)));
         assertFalse(conf.isInsecure(ContainerRef.parse("localhost:5000/library/test:latest")));
         assertFalse(conf.isInsecure(ContainerRef.parse("localhost:5001/library/test:latest")));
+        assertDoesNotThrow(conf::enforceShortNameMode);
     }
 
     @Test
@@ -107,6 +113,7 @@ class RegistryConfTest {
         RegistriesConf conf = new RegistriesConf(new RegistriesConf.Config(List.of(registry)));
         assertFalse(conf.isBlocked(ContainerRef.parse("localhost:5000/library/test:latest")));
         assertFalse(conf.isBlocked(ContainerRef.parse("localhost:5001/library/test:latest")));
+        assertDoesNotThrow(conf::enforceShortNameMode);
 
         // With blocked true
         registry = new RegistriesConf.RegistryConfig("localhost:5000", null, true, null);


### PR DESCRIPTION
Fix https://github.com/oras-project/oras-java/issues/548

### Description

Allow setting short-name-mode and set mode to enforcing by default

### Testing done

Added some tests

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
