### PR TITLE
Fix `getEffectiveRegistry` to return registry only

### DIFF
--- a/src/main/java/land/oras/auth/RegistriesConf.java
+++ b/src/main/java/land/oras/auth/RegistriesConf.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.Optional;
 import land.oras.ContainerRef;
 import land.oras.exception.OrasException;
+import land.oras.utils.Const;
 import land.oras.utils.TomlUtils;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -193,6 +194,17 @@ public class RegistriesConf {
     }
 
     /**
+     * Return the key of the alias
+     * @param ref the container reference to get the alias key for.
+     * @return the alias key for the given container reference, which is either the repository name
+     */
+    public String getAliasKey(ContainerRef ref) {
+        return ref.getRegistry().equals(Const.DEFAULT_REGISTRY) && "library".equals(ref.getNamespace())
+                ? ref.getRepository()
+                : ref.getFullRepository();
+    }
+
+    /**
      * Enforce the short name mode by checking the configuration. If the short name mode is set to ENFORCING or PERMISSIVE and there are multiple unqualified registries configured, this method throws an OrasException indicating that the configuration is invalid. If the configuration is valid, this method does nothing.
      * @throws OrasException if the short name mode is set to ENFORCING or PERMISSIVE and there are multiple unqualified registries configured, indicating that the configuration is invalid.
      */
@@ -250,6 +262,7 @@ public class RegistriesConf {
      * @return the rewritten container reference.
      */
     public ContainerRef rewrite(ContainerRef ref) {
+
         Optional<RegistryConfig> matchingConfig = selectMatchingTable(ref);
         if (matchingConfig.isEmpty()) {
             return ref;

--- a/src/test/java/land/oras/ContainerRefTest.java
+++ b/src/test/java/land/oras/ContainerRefTest.java
@@ -85,8 +85,8 @@ class ContainerRefTest {
         String config =
                 """
             [aliases]
-            "my-library/my-namespace"="localhost/test"
-            "my-library"="localhost/test2"
+            "my-library/my-namespace"="localhost:5000/test"
+            "my-library"="localhost:5000/test2"
             """;
 
         TestUtils.createRegistriesConfFile(homeDir, config);
@@ -94,9 +94,9 @@ class ContainerRefTest {
         TestUtils.withHome(homeDir, () -> {
             Registry registry = Registry.builder().defaults().build();
             ContainerRef unqualifiedRef = ContainerRef.parse("my-library/my-namespace");
-            assertEquals("localhost/test", unqualifiedRef.getEffectiveRegistry(registry));
+            assertEquals("localhost:5000", unqualifiedRef.getEffectiveRegistry(registry));
             ContainerRef unqualifiedRef2 = ContainerRef.parse("my-library");
-            assertEquals("localhost/test2", unqualifiedRef2.getEffectiveRegistry(registry));
+            assertEquals("localhost:5000", unqualifiedRef2.getEffectiveRegistry(registry));
         });
     }
 


### PR DESCRIPTION
### Description

Fix getEffectiveRegistry to return registry only

### Testing done

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
