### PR TITLE
Layer annotations where not added on files during pushArtifact

### DIFF
--- a/src/main/java/land/oras/Annotations.java
+++ b/src/main/java/land/oras/Annotations.java
@@ -86,6 +86,27 @@ public record Annotations(
     }
 
     /**
+     * Check if there are annotations for a file
+     * @param key The key
+     * @return True if there are annotations, false otherwise
+     */
+    public boolean hasFileAnnotations(String key) {
+        return this.filesAnnotations().containsKey(key);
+    }
+
+    /**
+     * Create a new annotations record with the given file annotations
+     * @param key The key of the file annotations
+     * @param annotations The file annotations
+     * @return The new annotations record
+     */
+    public Annotations withFileAnnotations(String key, Map<String, String> annotations) {
+        Map<String, Map<String, String>> newFilesAnnotations = new HashMap<>(this.filesAnnotations());
+        newFilesAnnotations.put(key, annotations);
+        return new Annotations(this.configAnnotations(), this.manifestAnnotations(), newFilesAnnotations);
+    }
+
+    /**
      * Annotations file format
      */
     private static class AnnotationFile extends HashMap<String, Map<String, String>> {

--- a/src/main/java/land/oras/OCILayout.java
+++ b/src/main/java/land/oras/OCILayout.java
@@ -83,7 +83,7 @@ public final class OCILayout extends OCI<LayoutRef> {
         }
 
         // Push layers
-        List<Layer> layers = pushLayers(ref, true, paths);
+        List<Layer> layers = pushLayers(ref, annotations, true, paths);
 
         // Push the config like any other blob
         Config configToPush = config != null ? config : Config.empty();

--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -406,7 +406,7 @@ public final class Registry extends OCI<ContainerRef> {
         ContainerRef resolvedRef = containerRef.forRegistry(this).forRegistry(resolvedRegistry);
 
         // Push layers
-        List<Layer> layers = pushLayers(resolvedRef, false, paths);
+        List<Layer> layers = pushLayers(resolvedRef, annotations, false, paths);
 
         // Add layer and config
         manifest = manifest.withLayers(layers).withConfig(pushedConfig);

--- a/src/test/java/land/oras/AnnotationsTest.java
+++ b/src/test/java/land/oras/AnnotationsTest.java
@@ -21,6 +21,8 @@
 package land.oras;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -49,6 +51,14 @@ class AnnotationsTest {
         assertEquals(0, annotations.configAnnotations().size());
         assertEquals(0, annotations.manifestAnnotations().size());
         assertEquals(0, annotations.filesAnnotations().size());
+    }
+
+    @Test
+    public void shouldAddFileAnnotation() {
+        Annotations annotations = Annotations.empty().withFileAnnotations("cake.txt", Map.of("fun", "more cream"));
+        assertEquals("more cream", annotations.getFileAnnotations("cake.txt").get("fun"));
+        assertTrue(annotations.hasFileAnnotations("cake.txt"));
+        assertFalse(annotations.hasFileAnnotations("nonexistent.txt"));
     }
 
     @Test


### PR DESCRIPTION
### Description

Layer annotations where not added on files during pushArtifact

### Testing done

Updated one test

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
