### PR TITLE
Add zip compression for artifact but never unpack it (Not a standard OCI layer mediatype)

### DIFF
--- a/src/main/java/land/oras/utils/Const.java
+++ b/src/main/java/land/oras/utils/Const.java
@@ -134,6 +134,11 @@ public final class Const {
     public static final String BLOB_DIR_ZSTD_MEDIA_TYPE = "application/vnd.oci.image.layer.v1.tar+zstd";
 
     /**
+     * Zip media type
+     */
+    public static final String ZIP_MEDIA_TYPE = "application/zip";
+
+    /**
      * The default artifact media type if not specified
      */
     public static final String DEFAULT_ARTIFACT_MEDIA_TYPE = "application/vnd.unknown.artifact.v1";


### PR DESCRIPTION
### Description

Add zip compression for artifact but never unpack it (since it's not a standard OCI layer mediatype)

Fix https://github.com/oras-project/oras-java/issues/592

### Testing done

mvn clean install
Added one test that push/pull artifact

Also did some interactive tests

```bash
java -jar java-oras-cli/target/oras-java.jar push --file java-oras-cli:application/zip localhost:5000/java-oras-cli:latest
oras pull localhost:5000/java-oras-cli:latest
unzip java-oras-cli.zip
```

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
