### PR TITLE
Add utils to remove one descriptor from Index

### DIFF
--- a/src/main/java/land/oras/Index.java
+++ b/src/main/java/land/oras/Index.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiPredicate;
+import land.oras.exception.OrasException;
 import land.oras.utils.Const;
 import land.oras.utils.JsonUtils;
 import org.jspecify.annotations.NonNull;
@@ -201,6 +202,36 @@ public final class Index extends Descriptor implements Describable {
     @SuppressWarnings("unused")
     public String getArtifactTypeAsString() {
         return artifactType;
+    }
+
+    /**
+     * Return a new index with the given manifest descriptor removed from the index
+     * @param descriptor The manifest descriptor to remove
+     * @return The index with the manifest descriptor removed
+     */
+    public Index withRemovedDescriptor(ManifestDescriptor descriptor) {
+        List<ManifestDescriptor> newManifests = new LinkedList<>(manifests);
+        boolean found = false;
+        for (ManifestDescriptor d : manifests) {
+            if (d.getDigest().equals(descriptor.getDigest())) {
+                found = true;
+                newManifests.remove(d);
+            }
+        }
+        if (!found) {
+            throw new OrasException("Cannot remove manifest descriptor with digest " + descriptor.getDigest()
+                    + " because it does not exist in the index");
+        }
+        return new Index(
+                schemaVersion,
+                mediaType,
+                ArtifactType.from(artifactType),
+                newManifests,
+                annotations,
+                subject,
+                this.descriptor,
+                registry,
+                json);
     }
 
     /**

--- a/src/test/java/land/oras/IndexTest.java
+++ b/src/test/java/land/oras/IndexTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
+import land.oras.exception.OrasException;
 import land.oras.utils.Const;
 import land.oras.utils.SupportedAlgorithm;
 import org.junit.jupiter.api.Test;
@@ -116,6 +117,28 @@ class IndexTest {
                 index.getManifests().get(0).getDigest());
         assertEquals(559, index.getManifests().get(0).getSize());
         assertEquals(json, index.toJson());
+    }
+
+    @Test
+    void shouldRemoveManifest() {
+
+        // Create 2 descriptors
+        Manifest newManifest1 = Manifest.empty().withAnnotations(Map.of("foo", "bar"));
+        ManifestDescriptor descriptor1 = ManifestDescriptor.of(newManifest1);
+        Manifest newManifest2 = Manifest.empty().withAnnotations(Map.of("foo1", "bar2"));
+        ManifestDescriptor descriptor2 = ManifestDescriptor.of(newManifest2);
+
+        Index index = Index.fromManifests(List.of(descriptor1, descriptor2));
+        assertEquals(2, index.getManifests().size());
+
+        final Index indexFinal = index.withRemovedDescriptor(descriptor1);
+        assertEquals(1, indexFinal.getManifests().size());
+        assertEquals(descriptor2.getDigest(), indexFinal.getManifests().get(0).getDigest());
+
+        OrasException e = assertThrows(OrasException.class, () -> indexFinal.withRemovedDescriptor(descriptor1));
+        assertEquals(
+                "Cannot remove manifest descriptor with digest sha256:d37ee97188d29dd838306ac7c5d35c03cc4cdac37c6a9e98529fee5aa0d65635 because it does not exist in the index",
+                e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
### Description

Add utils to remove one descriptor from Index

### Testing done

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
