### PR TITLE
Fix index serialization when adding manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ target/
 # IDEs
 .idea/
 *.iml
+.classpath
+.project
+.settings
 
 # When testing JSON files
 *.json

--- a/src/main/java/land/oras/CopyUtils.java
+++ b/src/main/java/land/oras/CopyUtils.java
@@ -146,8 +146,8 @@ public final class CopyUtils {
             }
 
             LOG.debug("Copying index {}", manifestDigest);
-            target.pushIndex(effectiveTargetRef.withDigest(tag), index);
-            LOG.debug("Copied index {}", manifestDigest);
+            Index pushedIndex = target.pushIndex(effectiveTargetRef.withDigest(tag), index);
+            LOG.debug("Copied index {} with tag {}", pushedIndex, tag);
 
         } else {
             throw new OrasException("Unsupported content type: %s".formatted(contentType));

--- a/src/main/java/land/oras/Index.java
+++ b/src/main/java/land/oras/Index.java
@@ -225,7 +225,7 @@ public final class Index extends Descriptor implements Describable {
         return new Index(
                 schemaVersion,
                 mediaType,
-                ArtifactType.from(artifactType),
+                artifactType,
                 newManifests,
                 annotations,
                 subject,
@@ -270,18 +270,11 @@ public final class Index extends Descriptor implements Describable {
         }
         newManifests.add(manifest);
         return new Index(
-                schemaVersion,
-                mediaType,
-                ArtifactType.from(artifactType),
-                newManifests,
-                annotations,
-                subject,
-                descriptor,
-                registry,
-                json);
+                schemaVersion, mediaType, artifactType, newManifests, annotations, subject, descriptor, registry, json);
     }
 
     @Override
+    @JsonIgnore
     public ManifestDescriptor getDescriptor() {
         return descriptor;
     }

--- a/src/test/java/land/oras/IndexTest.java
+++ b/src/test/java/land/oras/IndexTest.java
@@ -134,6 +134,8 @@ class IndexTest {
         final Index indexFinal = index.withRemovedDescriptor(descriptor1);
         assertEquals(1, indexFinal.getManifests().size());
         assertEquals(descriptor2.getDigest(), indexFinal.getManifests().get(0).getDigest());
+        assertNull(index.getArtifactTypeAsString());
+        assertNull(indexFinal.getArtifactTypeAsString());
 
         OrasException e = assertThrows(OrasException.class, () -> indexFinal.withRemovedDescriptor(descriptor1));
         assertEquals(

--- a/src/test/java/land/oras/OCILayoutTest.java
+++ b/src/test/java/land/oras/OCILayoutTest.java
@@ -1042,9 +1042,12 @@ class OCILayoutTest {
     private void assertIndex(Path ociLayoutPath, Index index, int size) {
         assertTrue(Files.exists(ociLayoutPath.resolve(Const.OCI_LAYOUT_INDEX)));
         Index ociIndex = Index.fromPath(ociLayoutPath.resolve(Const.OCI_LAYOUT_INDEX));
-        LOG.debug("Index is {}", ociIndex.toJson());
+        LOG.debug("OCI Index JSON is {}", ociIndex.toJson());
+        LOG.debug("Expected Index JSON is {}", index.toJson());
         assertEquals(2, ociIndex.getSchemaVersion());
         assertEquals(size, ociIndex.getManifests().size());
+        assertEquals(index.getArtifactType(), ociIndex.getArtifactType());
+        assertEquals(index.getArtifactTypeAsString(), ociIndex.getArtifactTypeAsString());
         assertEquals(Const.DEFAULT_INDEX_MEDIA_TYPE, ociIndex.getMediaType());
         assertEquals(
                 index.getDescriptor().getSize(),


### PR DESCRIPTION
### Description

Artifact type was wrongly copied when adding or removing manifests

Added assertion to prevent this issue 

Found while debugging https://github.com/oras-project/oras-java/pull/610

### Testing done

mvn clean install

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
