### PR TITLE
Increase Maven central publication waitMaxTime to 2h (30mn fail too often)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,6 +467,13 @@
             <publishingServerId>central</publishingServerId>
             <autoPublish>true</autoPublish>
             <waitUntil>published</waitUntil>
+
+            <!-- 2 hours. Default is 30 minutes which is too short -->
+            <waitMaxTime>7200</waitMaxTime>
+
+            <!-- Default is 5 seconds, which is too short and increase risk of request failing -->
+            <waitPollingInterval>30</waitPollingInterval>
+
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
### Description

Increase Maven central publication waitMaxTime to 2h (30mn fail too often)

### Testing done

None

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
