### PR TITLE
Concurrency for layer pull and push

### DIFF
--- a/src/main/java/land/oras/CopyUtils.java
+++ b/src/main/java/land/oras/CopyUtils.java
@@ -21,6 +21,7 @@ package land.oras;
  */
 
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import land.oras.exception.OrasException;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
@@ -107,17 +108,20 @@ public final class CopyUtils {
                     OCI<TargetRefType> target,
                     TargetRefType targetRef,
                     String contentType) {
-        for (Layer layer : source.collectLayers(sourceRef, contentType, true)) {
-            Objects.requireNonNull(layer.getDigest(), "Layer digest is required for streaming copy");
-            Objects.requireNonNull(layer.getSize(), "Layer size is required for streaming copy");
-            LOG.debug("Copying layer {}", layer.getDigest());
-            target.pushBlob(
-                    targetRef.withDigest(layer.getDigest()),
-                    layer.getSize(),
-                    () -> source.fetchBlob(sourceRef.withDigest(layer.getDigest())),
-                    layer.getAnnotations());
-            LOG.debug("Copied layer {}", layer.getDigest());
-        }
+        CompletableFuture.allOf(source.collectLayers(sourceRef, contentType, true).stream()
+                        .map(layer -> {
+                            Objects.requireNonNull(layer.getDigest(), "Layer digest is required for streaming copy");
+                            Objects.requireNonNull(layer.getSize(), "Layer size is required for streaming copy");
+                            return CompletableFuture.runAsync(
+                                    () -> target.pushBlob(
+                                            targetRef.withDigest(layer.getDigest()),
+                                            layer.getSize(),
+                                            () -> source.fetchBlob(sourceRef.withDigest(layer.getDigest())),
+                                            layer.getAnnotations()),
+                                    source.getExecutorService());
+                        })
+                        .toArray(CompletableFuture[]::new))
+                .join();
     }
 
     /**

--- a/src/main/java/land/oras/OCI.java
+++ b/src/main/java/land/oras/OCI.java
@@ -27,11 +27,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import land.oras.exception.OrasException;
 import land.oras.utils.ArchiveUtils;
@@ -170,77 +173,15 @@ public abstract sealed class OCI<T extends Ref<@NonNull T>> permits Registry, OC
      * @return The layers
      */
     protected final List<Layer> pushLayers(T ref, Annotations annotations, boolean withDigest, LocalPath... paths) {
-        List<Layer> layers = new ArrayList<>();
-        for (LocalPath path : paths) {
-            try {
-                // Create tar.gz archive for directory
-                if (Files.isDirectory(path.getPath())) {
-                    SupportedCompression compression = SupportedCompression.fromMediaType(path.getMediaType());
-
-                    // If source need to be packed first
-                    boolean autoUnpack = compression.isAutoUnpack();
-                    LocalPath tempSource = autoUnpack ? ArchiveUtils.tar(path) : path;
-                    LocalPath tempArchive = ArchiveUtils.compress(tempSource, path.getMediaType());
-
-                    if (withDigest) {
-                        ref = ref.withDigest(ref.getAlgorithm().digest(tempArchive.getPath()));
-                    }
-                    try (InputStream is = Files.newInputStream(tempArchive.getPath())) {
-                        String title = path.getPath().isAbsolute()
-                                ? path.getPath().getFileName().toString()
-                                : path.getPath().toString();
-
-                        // We store the filename, based on directory name if we don't auto unpack
-                        if (!autoUnpack) {
-                            title = "%s.%s".formatted(title, compression.getFileExtension());
-                        }
-                        LOG.debug("Uploading directory as archive with title: {}", title);
-
-                        Map<String, String> layerAnnotations = annotations.hasFileAnnotations(title)
-                                ? annotations.getFileAnnotations(title)
-                                : new LinkedHashMap<>(Map.of(Const.ANNOTATION_TITLE, title));
-
-                        // Add oras digest/unpack
-                        // For example zip can be packed application/zip but never unpacked by the runtime
-                        // This is convenience method to pack zip layer as directories
-                        if (compression.isAutoUnpack()) {
-                            layerAnnotations.put(
-                                    Const.ANNOTATION_ORAS_CONTENT_DIGEST,
-                                    ref.getAlgorithm().digest(tempSource.getPath()));
-                            layerAnnotations.put(Const.ANNOTATION_ORAS_UNPACK, "true");
-                        } else {
-                            layerAnnotations.put(Const.ANNOTATION_ORAS_UNPACK, "false");
-                        }
-
-                        Layer layer = pushBlob(ref, is)
-                                .withMediaType(path.getMediaType())
-                                .withAnnotations(layerAnnotations);
-                        layers.add(layer);
-                        LOG.info("Uploaded directory: {}", layer.getDigest());
-                    }
-                    Files.delete(tempArchive.getPath());
-                } else {
-                    try (InputStream is = Files.newInputStream(path.getPath())) {
-                        if (withDigest) {
-                            ref = ref.withDigest(ref.getAlgorithm().digest(path.getPath()));
-                        }
-                        String title = path.getPath().getFileName().toString();
-                        Map<String, String> layerAnnotations = annotations.hasFileAnnotations(title)
-                                ? annotations.getFileAnnotations(title)
-                                : Map.of(Const.ANNOTATION_TITLE, title);
-
-                        Layer layer = pushBlob(ref, is)
-                                .withMediaType(path.getMediaType())
-                                .withAnnotations(layerAnnotations);
-                        layers.add(layer);
-                        LOG.info("Uploaded: {}", layer.getDigest());
-                    }
-                }
-            } catch (IOException e) {
-                throw new OrasException("Failed to push artifact", e);
-            }
+        try {
+            return Arrays.stream(paths)
+                    .map(p -> CompletableFuture.supplyAsync(
+                            () -> pushLayer(ref, annotations, withDigest, p), getExecutorService()))
+                    .map(CompletableFuture::join)
+                    .toList();
+        } catch (CompletionException e) {
+            throw new OrasException("Failed to push layers", e.getCause());
         }
-        return layers;
     }
 
     /**
@@ -306,6 +247,12 @@ public abstract sealed class OCI<T extends Ref<@NonNull T>> permits Registry, OC
      * @return The tags
      */
     public abstract Tags getTags(T ref);
+
+    /**
+     * Get the executor service for concurrent operations. This is used for concurrent pushing and pulling of layers.
+     * @return The executor service
+     */
+    public abstract ExecutorService getExecutorService();
 
     /**
      * Get the tags for a ref
@@ -482,5 +429,73 @@ public abstract sealed class OCI<T extends Ref<@NonNull T>> permits Registry, OC
                 ref.withDigest(
                         SupportedAlgorithm.getDefault().digest(manifest.toJson().getBytes(StandardCharsets.UTF_8))),
                 manifest);
+    }
+
+    protected Layer pushLayer(T ref, Annotations annotations, boolean withDigest, LocalPath path) {
+        try {
+            // Create tar.gz archive for directory
+            if (Files.isDirectory(path.getPath())) {
+                SupportedCompression compression = SupportedCompression.fromMediaType(path.getMediaType());
+
+                // If source need to be packed first
+                boolean autoUnpack = compression.isAutoUnpack();
+                LocalPath tempSource = autoUnpack ? ArchiveUtils.tar(path) : path;
+                LocalPath tempArchive = ArchiveUtils.compress(tempSource, path.getMediaType());
+
+                if (withDigest) {
+                    ref = ref.withDigest(ref.getAlgorithm().digest(tempArchive.getPath()));
+                }
+                try (InputStream is = Files.newInputStream(tempArchive.getPath())) {
+                    String title = path.getPath().isAbsolute()
+                            ? path.getPath().getFileName().toString()
+                            : path.getPath().toString();
+
+                    // We store the filename, based on directory name if we don't auto unpack
+                    if (!autoUnpack) {
+                        title = "%s.%s".formatted(title, compression.getFileExtension());
+                    }
+                    LOG.debug("Uploading directory as archive with title: {}", title);
+
+                    Map<String, String> layerAnnotations = annotations.hasFileAnnotations(title)
+                            ? annotations.getFileAnnotations(title)
+                            : new LinkedHashMap<>(Map.of(Const.ANNOTATION_TITLE, title));
+
+                    // Add oras digest/unpack
+                    // For example zip can be packed application/zip but never unpacked by the runtime
+                    // This is convenience method to pack zip layer as directories
+                    if (compression.isAutoUnpack()) {
+                        layerAnnotations.put(
+                                Const.ANNOTATION_ORAS_CONTENT_DIGEST,
+                                ref.getAlgorithm().digest(tempSource.getPath()));
+                        layerAnnotations.put(Const.ANNOTATION_ORAS_UNPACK, "true");
+                    } else {
+                        layerAnnotations.put(Const.ANNOTATION_ORAS_UNPACK, "false");
+                    }
+
+                    Layer layer =
+                            pushBlob(ref, is).withMediaType(path.getMediaType()).withAnnotations(layerAnnotations);
+                    LOG.info("Uploaded directory: {}", layer.getDigest());
+                    Files.delete(tempArchive.getPath());
+                    return layer;
+                }
+            } else {
+                try (InputStream is = Files.newInputStream(path.getPath())) {
+                    if (withDigest) {
+                        ref = ref.withDigest(ref.getAlgorithm().digest(path.getPath()));
+                    }
+                    String title = path.getPath().getFileName().toString();
+                    Map<String, String> layerAnnotations = annotations.hasFileAnnotations(title)
+                            ? annotations.getFileAnnotations(title)
+                            : Map.of(Const.ANNOTATION_TITLE, title);
+
+                    Layer layer =
+                            pushBlob(ref, is).withMediaType(path.getMediaType()).withAnnotations(layerAnnotations);
+                    LOG.info("Uploaded: {}", layer.getDigest());
+                    return layer;
+                }
+            }
+        } catch (IOException e) {
+            throw new OrasException("Failed to push artifact", e);
+        }
     }
 }

--- a/src/main/java/land/oras/OCILayout.java
+++ b/src/main/java/land/oras/OCILayout.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import land.oras.exception.OrasException;
 import land.oras.utils.Const;
@@ -44,6 +46,8 @@ public final class OCILayout extends OCI<LayoutRef> {
 
     @SuppressWarnings("all")
     private final String imageLayoutVersion = "1.0.0";
+
+    private final ExecutorService executors = Executors.newSingleThreadExecutor();
 
     /**
      * Path on the file system of the OCI Layout
@@ -61,6 +65,11 @@ public final class OCILayout extends OCI<LayoutRef> {
      */
     public static OCILayout.Builder builder() {
         return OCILayout.Builder.builder();
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        return executors;
     }
 
     @Override

--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -33,6 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import land.oras.auth.AuthProvider;
 import land.oras.auth.AuthStoreAuthenticationProvider;
@@ -54,6 +57,16 @@ import org.jspecify.annotations.Nullable;
  */
 @NullMarked
 public final class Registry extends OCI<ContainerRef> {
+
+    /**
+     * Max concurrent downloads and upload for blobs
+     */
+    private int maxConcurrentDownloads = 1;
+
+    /**
+     * The executor service for parallel operations
+     */
+    private ExecutorService executors;
 
     /**
      * The registries configuration loaded from the environment
@@ -119,6 +132,14 @@ public final class Registry extends OCI<ContainerRef> {
     }
 
     /**
+     * Set the max concurrent downloads and uploads for blobs. Default to number of available processors
+     * @param maxConcurrentDownloads Max concurrent downloads and uploads for blobs
+     */
+    private void setParallelism(int maxConcurrentDownloads) {
+        this.maxConcurrentDownloads = maxConcurrentDownloads;
+    }
+
+    /**
      * Return if this registry is insecure
      * @return True if insecure
      */
@@ -156,6 +177,11 @@ public final class Registry extends OCI<ContainerRef> {
      */
     private Registry build() {
         client = HttpClient.Builder.builder().withSkipTlsVerify(skipTlsVerify).build();
+        executors = Executors.newFixedThreadPool(maxConcurrentDownloads, r -> {
+            Thread t = new Thread(r);
+            t.setName("layer-transfer-worker-%d".formatted(t.getId()));
+            return t;
+        });
         return this;
     }
 
@@ -190,6 +216,11 @@ public final class Registry extends OCI<ContainerRef> {
      */
     public @Nullable String getRegistry() {
         return registry;
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        return executors;
     }
 
     @Override
@@ -374,45 +405,17 @@ public final class Registry extends OCI<ContainerRef> {
             LOG.info("Skipped pulling layers without file name in '{}'", Const.ANNOTATION_TITLE);
             return;
         }
-        for (Layer layer : layers) {
-            if (!layer.getAnnotations().containsKey(Const.ANNOTATION_TITLE)) {
-                LOG.info("Skipped pulling layer without file name in '{}'", Const.ANNOTATION_TITLE);
-                continue;
-            }
-            try (InputStream is = fetchBlob(ref.withDigest(layer.getDigest()))) {
-                // Unpack or just copy blob
-                if (Boolean.parseBoolean(layer.getAnnotations().getOrDefault(Const.ANNOTATION_ORAS_UNPACK, "false"))) {
-                    LOG.debug("Extracting blob to: {}", path);
-
-                    // Uncompress the tar.gz archive and verify digest if present
-                    LocalPath tempArchive = ArchiveUtils.uncompress(is, layer.getMediaType());
-                    String expectedDigest = layer.getAnnotations().get(Const.ANNOTATION_ORAS_CONTENT_DIGEST);
-                    if (expectedDigest != null) {
-                        LOG.trace("Expected digest: {}", expectedDigest);
-                        String actualDigest = ref.getAlgorithm().digest(tempArchive.getPath());
-                        LOG.trace("Actual digest: {}", actualDigest);
-                        if (!expectedDigest.equals(actualDigest)) {
-                            throw new OrasException(
-                                    "Digest mismatch: expected %s but got %s".formatted(expectedDigest, actualDigest));
-                        }
-                    }
-
-                    // Extract the tar
-                    ArchiveUtils.untar(Files.newInputStream(tempArchive.getPath()), path);
-
-                } else {
-                    Path targetPath = path.resolve(layer.getAnnotations().get(Const.ANNOTATION_TITLE));
-                    if (Files.exists(targetPath) && !overwrite) {
-                        LOG.info("File already exists: {}", targetPath);
-                        continue;
-                    }
-                    LOG.debug("Copying blob to: {}", targetPath);
-                    Files.copy(is, targetPath, StandardCopyOption.REPLACE_EXISTING);
-                }
-            } catch (IOException e) {
-                throw new OrasException("Failed to pull artifact", e);
-            }
+        if (layers.stream().noneMatch(layer -> layer.getAnnotations().containsKey(Const.ANNOTATION_TITLE))) {
+            LOG.info("Skipped pulling artifact without file name in '{}'", Const.ANNOTATION_TITLE);
+            return;
         }
+        // Pull layers in parallel
+        CompletableFuture.allOf(layers.stream()
+                        .filter(layer -> layer.getAnnotations().containsKey(Const.ANNOTATION_TITLE))
+                        .map(layer -> CompletableFuture.runAsync(
+                                () -> pullLayer(ref, layer, path, overwrite), getExecutorService()))
+                        .toArray(CompletableFuture[]::new))
+                .join();
     }
 
     @Override
@@ -948,6 +951,43 @@ public final class Registry extends OCI<ContainerRef> {
         return getResolvedHeaders(containerRef).headers().get(Const.CONTENT_TYPE_HEADER.toLowerCase());
     }
 
+    private void pullLayer(ContainerRef ref, Layer layer, Path path, boolean overwrite) {
+        Objects.requireNonNull(layer.getDigest());
+        try (InputStream is = fetchBlob(ref.withDigest(layer.getDigest()))) {
+            // Unpack or just copy blob
+            if (Boolean.parseBoolean(layer.getAnnotations().getOrDefault(Const.ANNOTATION_ORAS_UNPACK, "false"))) {
+                LOG.debug("Extracting blob to: {}", path);
+
+                // Uncompress the tar.gz archive and verify digest if present
+                LocalPath tempArchive = ArchiveUtils.uncompress(is, layer.getMediaType());
+                String expectedDigest = layer.getAnnotations().get(Const.ANNOTATION_ORAS_CONTENT_DIGEST);
+                if (expectedDigest != null) {
+                    LOG.trace("Expected digest: {}", expectedDigest);
+                    String actualDigest = ref.getAlgorithm().digest(tempArchive.getPath());
+                    LOG.trace("Actual digest: {}", actualDigest);
+                    if (!expectedDigest.equals(actualDigest)) {
+                        throw new OrasException(
+                                "Digest mismatch: expected %s but got %s".formatted(expectedDigest, actualDigest));
+                    }
+                }
+
+                // Extract the tar
+                ArchiveUtils.untar(Files.newInputStream(tempArchive.getPath()), path);
+
+            } else {
+                Path targetPath = path.resolve(layer.getAnnotations().get(Const.ANNOTATION_TITLE));
+                if (Files.exists(targetPath) && !overwrite) {
+                    LOG.info("File already exists: {}", targetPath);
+                    return;
+                }
+                LOG.debug("Copying blob to: {}", targetPath);
+                Files.copy(is, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new OrasException("Failed to pull artifact", e);
+        }
+    }
+
     /**
      * Append digest to location header returned from upload post
      * @param location The location header from upload post
@@ -1068,6 +1108,7 @@ public final class Registry extends OCI<ContainerRef> {
             this.registry.setInsecure(registry.insecure);
             this.registry.setRegistry(registry.registry);
             this.registry.setSkipTlsVerify(registry.skipTlsVerify);
+            this.registry.setParallelism(registry.maxConcurrentDownloads);
             return this;
         }
 
@@ -1141,6 +1182,16 @@ public final class Registry extends OCI<ContainerRef> {
          */
         public Builder withAuthProvider(AuthProvider authProvider) {
             registry.setAuthProvider(authProvider);
+            return this;
+        }
+
+        /**
+         * Set the maximum number of concurrent downloads when pulling an artifact with multiple layers. Default is 4.
+         * @param parallelism The maximum number of parallel uploads/download
+         * @return The builder
+         */
+        public Builder withParallelism(int parallelism) {
+            registry.setParallelism(parallelism);
             return this;
         }
 

--- a/src/test/java/land/oras/DockerIoITCase.java
+++ b/src/test/java/land/oras/DockerIoITCase.java
@@ -106,11 +106,13 @@ class DockerIoITCase {
     void shouldCopyTagToInternalRegistry() {
 
         // Source registry
-        Registry sourceRegistry = Registry.Builder.builder().defaults().build();
+        Registry sourceRegistry =
+                Registry.Builder.builder().withParallelism(10).defaults().build();
 
         // Copy to this internal registry
         Registry targetRegistry = Registry.Builder.builder()
                 .defaults("myuser", "mypass")
+                .withParallelism(10)
                 .withInsecure(true)
                 .build();
 


### PR DESCRIPTION
### Description

Delegate pull/push layer to a dedicated Executor service with given parallelism.

Would improve performance for artifact of multiple layer or when copying from one Registry to an other

### Testing done

Automated tests.

Will run more interactive tests using SNAPSHOT on main branch

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
