### PR TITLE
Change JUnit dependency scope from compile to scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,10 +224,6 @@
       <artifactId>jspecify</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -263,6 +259,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Description

The `org.junit.jupiter:junit-jupiter-params` dependency was mistakenly declared with `compile` scope, resulting in it being included in the final production artifact published to Maven Central. I fixed it by declaring it with `test` scope.

Fixes gh-665

### Testing done

I ran the entire test suite and it succeeded.

### Submitter checklist
- [X] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [X] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
