### PR TITLE
Allow to pass auth token to build registry

### DIFF
--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import land.oras.auth.AuthProvider;
 import land.oras.auth.AuthStoreAuthenticationProvider;
+import land.oras.auth.BearerTokenProvider;
 import land.oras.auth.HttpClient;
 import land.oras.auth.NoAuthProvider;
 import land.oras.auth.RegistriesConf;
@@ -292,6 +293,15 @@ public final class Registry extends OCI<ContainerRef> {
      */
     public Registry copy(String newRegistry) {
         return new Builder().from(this).withRegistry(newRegistry).build();
+    }
+
+    /**
+     * Return a new registry with a new auth external token and same settings
+     * @param authToken The new refreshed token
+     * @return The new registry
+     */
+    public Registry withAuthToken(String authToken) {
+        return new Builder().from(this).withAuthToken(authToken).build();
     }
 
     /**
@@ -1278,6 +1288,18 @@ public final class Registry extends OCI<ContainerRef> {
          */
         public Builder withAuthProvider(AuthProvider authProvider) {
             registry.setAuthProvider(authProvider);
+            return this;
+        }
+
+        /**
+         * Use given auth token for the registry.
+         * Useful when the auth token is obtained by other mean (like a token exchange).
+         * Caller are responsible to handle token expiration if any
+         * @param authToken The auth token
+         * @return The builder
+         */
+        public Builder withAuthToken(String authToken) {
+            registry.setAuthProvider(new BearerTokenProvider(authToken));
             return this;
         }
 

--- a/src/main/java/land/oras/auth/BearerTokenProvider.java
+++ b/src/main/java/land/oras/auth/BearerTokenProvider.java
@@ -48,6 +48,14 @@ public final class BearerTokenProvider implements AuthProvider {
     public BearerTokenProvider() {}
 
     /**
+     * Create a new bearer token provider
+     * @param token The token
+     */
+    public BearerTokenProvider(String token) {
+        setToken(new HttpClient.TokenResponse(token, null, null, null, null));
+    }
+
+    /**
      * Get the token
      * @return The token
      */

--- a/src/test/java/land/oras/RegistryWireMockTest.java
+++ b/src/test/java/land/oras/RegistryWireMockTest.java
@@ -84,6 +84,34 @@ class RegistryWireMockTest {
     private static Path homeDir3;
 
     @Test
+    void shouldPassBearerTokenWithExternalRequestedToken(WireMockRuntimeInfo wmRuntimeInfo) {
+        Registry registry = Registry.Builder.builder()
+                .insecure()
+                .withAuthToken("insecure-token")
+                .build();
+
+        // Ensure WireMock accept only our token
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/v2/library/artifact-text/tags/list"))
+                .withHeader("Authorization", equalTo("Bearer insecure-token"))
+                .willReturn(WireMock.okJson(JsonUtils.toJson(new Tags("artifact-text", List.of("latest", "0.1.1"))))));
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/v2/library/artifact-text/tags/list"))
+                .withHeader("Authorization", equalTo("Bearer invalid-token"))
+                .willReturn(WireMock.unauthorized()));
+
+        registry.getTags(ContainerRef.parse("%s/library/artifact-text"
+                .formatted(wmRuntimeInfo.getHttpBaseUrl().replace("http://", ""))));
+
+        // Ensure it fail with invalid token
+        final Registry newRegistry = registry.withAuthToken("invalid-token");
+        OrasException e = assertThrows(
+                OrasException.class,
+                () -> newRegistry.getTags(ContainerRef.parse("%s/library/artifact-text"
+                        .formatted(wmRuntimeInfo.getHttpBaseUrl().replace("http://", "")))));
+        assertEquals(401, e.getStatusCode());
+    }
+
+    @Test
     void shouldFailToGetManifestOn403(WireMockRuntimeInfo wmRuntimeInfo) {
 
         // Return data from wiremock


### PR DESCRIPTION
Fix https://github.com/oras-project/oras-java/issues/672

### Description

In some scenario the Bearer Auth token is requested by an other system (for example token exchange).

Allow to build a registry directly with Bearer authentication and allow to copy settings when the token change (responsibility of the caller to manager token)

### Testing done

Added tests

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
