### PR TITLE
Add missing @OrasModel annotation on CredentialHelperResponse

### DIFF
--- a/src/main/java/land/oras/auth/AuthStore.java
+++ b/src/main/java/land/oras/auth/AuthStore.java
@@ -341,6 +341,7 @@ public class AuthStore {
      * @param username The username
      * @param secret The secret (password or token)
      */
+    @OrasModel
     public record CredentialHelperResponse(
             @JsonProperty("ServerURL") String serverUrl,
             @JsonProperty("Username") String username,

--- a/src/test/java/land/oras/ClassAnnotationsTest.java
+++ b/src/test/java/land/oras/ClassAnnotationsTest.java
@@ -49,7 +49,7 @@ class ClassAnnotationsTest {
                     .loadClasses());
 
             // Check number of classes
-            assertEquals(25, modelClasses.size());
+            assertEquals(26, modelClasses.size());
 
             // Check classes
             assertTrue(modelClasses.contains(Annotations.class));
@@ -83,7 +83,7 @@ class ClassAnnotationsTest {
                     .loadClasses());
 
             // Check number of classes
-            assertEquals(7, modelClasses.size());
+            assertEquals(8, modelClasses.size());
         }
     }
 }


### PR DESCRIPTION
### Description

Add missing `@OrasModel` annotation on `CredentialHelperResponse` to allow access when compiled to a GraalVM native executable.

Fixes gh-684

### Testing done

Updated tests for for model annotations.

### Submitter checklist
- [X] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [X] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
