### PR TITLE
Support configuring custom CA certificates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bcprov-jdk18on.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
         <version>${bcprov-jdk18on.version}</version>
       </dependency>
@@ -260,6 +265,11 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -103,6 +103,16 @@ public final class Registry extends OCI<ContainerRef> {
     private boolean skipTlsVerify;
 
     /**
+     * Path to a PEM-encoded CA certificate or bundle for TLS verification
+     */
+    private @Nullable Path caFilePath;
+
+    /**
+     * PEM-encoded CA certificate or bundle content for TLS verification
+     */
+    private @Nullable String caContent;
+
+    /**
      * The meter registry for metrics
      */
     private @Nullable MeterRegistry meterRegistry;
@@ -251,6 +261,22 @@ public final class Registry extends OCI<ContainerRef> {
     }
 
     /**
+     * Set the CA file path for TLS verification
+     * @param caFilePath The path to a PEM-encoded CA certificate or bundle
+     */
+    private void setCaFilePath(Path caFilePath) {
+        this.caFilePath = caFilePath;
+    }
+
+    /**
+     * Set the CA certificate content for TLS verification
+     * @param caContent The PEM-encoded CA certificate or bundle content
+     */
+    private void setCaContent(String caContent) {
+        this.caContent = caContent;
+    }
+
+    /**
      * Set the meter registry for metrics
      * @param meterRegistry The meter registry
      */
@@ -264,6 +290,12 @@ public final class Registry extends OCI<ContainerRef> {
      */
     private Registry build() {
         HttpClient.Builder clientBuilder = HttpClient.Builder.builder().withSkipTlsVerify(skipTlsVerify);
+        if (caFilePath != null) {
+            clientBuilder = clientBuilder.withCaFile(caFilePath);
+        }
+        if (caContent != null) {
+            clientBuilder = clientBuilder.withCaContent(caContent);
+        }
         if (meterRegistry != null) {
             clientBuilder = clientBuilder.withMeterRegistry(meterRegistry);
         }
@@ -1341,6 +1373,35 @@ public final class Registry extends OCI<ContainerRef> {
          */
         public Builder withSkipTlsVerify(boolean skipTlsVerify) {
             registry.setSkipTlsVerify(skipTlsVerify);
+            return this;
+        }
+
+        /**
+         * Set the CA file for TLS verification
+         * @param caFilePath The path to a PEM-encoded CA certificate or bundle
+         * @return The builder
+         */
+        public Builder withCaFile(Path caFilePath) {
+            registry.setCaFilePath(caFilePath);
+            return this;
+        }
+
+        /**
+         * Set the CA file for TLS verification
+         * @param caFilePath The path to a PEM-encoded CA certificate or bundle
+         * @return The builder
+         */
+        public Builder withCaFile(String caFilePath) {
+            return withCaFile(Path.of(caFilePath));
+        }
+
+        /**
+         * Set the CA certificates from PEM-encoded content
+         * @param caContent The PEM-encoded CA certificate or bundle content
+         * @return The builder
+         */
+        public Builder withCaContent(String caContent) {
+            registry.setCaContent(caContent);
             return this;
         }
 

--- a/src/main/java/land/oras/auth/HttpClient.java
+++ b/src/main/java/land/oras/auth/HttpClient.java
@@ -23,17 +23,24 @@ package land.oras.auth;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.net.*;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyStore;
 import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +53,7 @@ import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
 import land.oras.ContainerRef;
 import land.oras.OrasModel;
@@ -91,6 +99,16 @@ public final class HttpClient {
     private boolean skipTlsVerify;
 
     /**
+     * Path to a PEM-encoded CA certificate or bundle
+     */
+    private @Nullable Path caFilePath;
+
+    /**
+     * PEM-encoded CA certificate or bundle content
+     */
+    private @Nullable String caContent;
+
+    /**
      * Timeout in seconds
      */
     private Integer timeout;
@@ -128,16 +146,93 @@ public final class HttpClient {
      * Skip the TLS verification
      * @param skipTlsVerify Skip TLS verification
      */
-    private void setTlsVerify(boolean skipTlsVerify) {
+    private void setSkipTlsVerify(boolean skipTlsVerify) {
         this.skipTlsVerify = skipTlsVerify;
-        if (skipTlsVerify) {
-            try {
-                SSLContext sslContext = SSLContext.getInstance("TLS");
-                sslContext.init(null, new TrustManager[] {new InsecureTrustManager()}, new SecureRandom());
-                builder.sslContext(sslContext);
-            } catch (Exception e) {
-                throw new OrasException("Unable to skip TLS verification", e);
-            }
+    }
+
+    /**
+     * Set the CA certificates for TLS verification from a file
+     * @param caFilePath The path to a PEM-encoded CA certificate or bundle
+     */
+    private void setCaFile(Path caFilePath) {
+        this.caFilePath = caFilePath;
+    }
+
+    /**
+     * Set the CA certificates for TLS verification from PEM-encoded content
+     * @param caContent The PEM-encoded CA certificate or bundle content
+     */
+    private void setCaContent(String caContent) {
+        this.caContent = caContent;
+    }
+
+    /**
+     * Configure SSL context from a PEM-encoded CA file
+     * @param caFilePath The path to a PEM-encoded CA certificate or bundle
+     */
+    private void configureTlsFromFile(Path caFilePath) {
+        try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(caFilePath))) {
+            configureCaCertificates(inputStream, "CA file: " + caFilePath);
+        } catch (OrasException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OrasException("Unable to configure CA file: " + caFilePath, e);
+        }
+    }
+
+    /**
+     * Configure SSL context from PEM-encoded CA content
+     * @param caContent The PEM-encoded CA certificate or bundle content
+     */
+    private void configureTlsFromContent(String caContent) {
+        try (InputStream inputStream = new ByteArrayInputStream(caContent.getBytes(StandardCharsets.UTF_8))) {
+            configureCaCertificates(inputStream, "CA content");
+        } catch (OrasException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OrasException("Unable to configure CA certificates from content", e);
+        }
+    }
+
+    /**
+     * Configure SSL context from PEM-encoded CA certificates read from the given input stream.
+     * @param inputStream The input stream containing PEM-encoded certificates
+     * @param source A description of the certificate source for error messages
+     */
+    private void configureCaCertificates(InputStream inputStream, String source) throws Exception {
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+
+        int certificateIndex = 0;
+        Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(inputStream);
+        if (certificates.isEmpty()) {
+            throw new OrasException("No certificates found in the provided " + source);
+        }
+        for (var certificate : certificates) {
+            trustStore.setCertificateEntry("ca-" + certificateIndex++, certificate);
+        }
+
+        TrustManagerFactory trustManagerFactory =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(trustStore);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustManagerFactory.getTrustManagers(), new SecureRandom());
+        builder.sslContext(sslContext);
+    }
+
+    /**
+     * Configure SSL context to skip TLS verification
+     */
+    private void configureInsecureTls() {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[] {new InsecureTrustManager()}, new SecureRandom());
+            builder.sslContext(sslContext);
+        } catch (Exception e) {
+            throw new OrasException("Unable to skip TLS verification", e);
         }
     }
 
@@ -146,6 +241,23 @@ public final class HttpClient {
      * @return The client
      */
     public HttpClient build() {
+        if (caFilePath != null && caContent != null) {
+            throw new OrasException(
+                    "Cannot configure both a CA file and CA content. Use either withCaFile() or withCaContent(), not both");
+        }
+        if (skipTlsVerify && (caFilePath != null || caContent != null)) {
+            throw new OrasException(
+                    "Cannot combine skipTlsVerify with a CA file or CA content. Use either withSkipTlsVerify() or withCaFile()/withCaContent(), not both");
+        }
+
+        if (skipTlsVerify) {
+            configureInsecureTls();
+        } else if (caFilePath != null) {
+            configureTlsFromFile(caFilePath);
+        } else if (caContent != null) {
+            configureTlsFromContent(caContent);
+        }
+
         this.client = this.builder.build();
         return this;
     }
@@ -778,7 +890,7 @@ public final class HttpClient {
          * @return The builder
          */
         public Builder withSkipTlsVerify(boolean skipTlsVerify) {
-            client.setTlsVerify(skipTlsVerify);
+            client.setSkipTlsVerify(skipTlsVerify);
             return this;
         }
 
@@ -789,6 +901,35 @@ public final class HttpClient {
          */
         public Builder withMeterRegistry(MeterRegistry meterRegistry) {
             client.meterRegistry = meterRegistry;
+            return this;
+        }
+
+        /**
+         * Set the CA file for TLS verification
+         * @param caFilePath The path to a PEM-encoded CA certificate or bundle
+         * @return The builder
+         */
+        public Builder withCaFile(Path caFilePath) {
+            client.setCaFile(caFilePath);
+            return this;
+        }
+
+        /**
+         * Set the CA file for TLS verification
+         * @param caFilePath The path to a PEM-encoded CA certificate or bundle
+         * @return The builder
+         */
+        public Builder withCaFile(String caFilePath) {
+            return withCaFile(Path.of(caFilePath));
+        }
+
+        /**
+         * Set the CA certificates from PEM-encoded content
+         * @param caContent The PEM-encoded CA certificate or bundle content
+         * @return The builder
+         */
+        public Builder withCaContent(String caContent) {
+            client.setCaContent(caContent);
             return this;
         }
 

--- a/src/test/java/land/oras/RegistryTlsTest.java
+++ b/src/test/java/land/oras/RegistryTlsTest.java
@@ -1,0 +1,109 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2026 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.security.KeyPair;
+import java.util.List;
+import javax.net.ssl.SSLHandshakeException;
+import land.oras.exception.OrasException;
+import land.oras.utils.TlsUtils;
+import land.oras.utils.ZotTlsContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@Execution(ExecutionMode.CONCURRENT)
+class RegistryTlsTest {
+
+    private static final String UNRELATED_CA_PEM;
+
+    static {
+        KeyPair keyPair = TlsUtils.generateKeyPair();
+        UNRELATED_CA_PEM = TlsUtils.toPem(TlsUtils.generateCaCertificate("unrelated-ca", keyPair));
+    }
+
+    @Container
+    private final ZotTlsContainer tlsRegistry = new ZotTlsContainer().withStartupAttempts(3);
+
+    @BeforeEach
+    void before() {
+        tlsRegistry.withFollowOutput();
+    }
+
+    @Test
+    void shouldConnectWithCaFile() {
+        Registry registry = Registry.builder()
+                .withRegistry(tlsRegistry.getRegistry())
+                .withCaFile(tlsRegistry.getCaCertPath())
+                .build();
+
+        List<String> repositories = registry.getRepositories().repositories();
+        assertNotNull(repositories);
+    }
+
+    @Test
+    void shouldConnectWithCaContent() {
+        Registry registry = Registry.builder()
+                .withRegistry(tlsRegistry.getRegistry())
+                .withCaContent(tlsRegistry.getCaCertContent())
+                .build();
+
+        List<String> repositories = registry.getRepositories().repositories();
+        assertNotNull(repositories);
+    }
+
+    @Test
+    void shouldFailWithoutCaCertificate() {
+        Registry registry =
+                Registry.builder().withRegistry(tlsRegistry.getRegistry()).build();
+
+        OrasException exception = assertThrows(OrasException.class, registry::getRepositories);
+        assertInstanceOf(SSLHandshakeException.class, exception.getCause());
+    }
+
+    @Test
+    void shouldFailWithWrongCaCertificate() {
+        Registry registry = Registry.builder()
+                .withRegistry(tlsRegistry.getRegistry())
+                .withCaContent(UNRELATED_CA_PEM)
+                .build();
+
+        OrasException exception = assertThrows(OrasException.class, registry::getRepositories);
+        assertInstanceOf(SSLHandshakeException.class, exception.getCause());
+    }
+
+    @Test
+    void shouldConnectWithSkipTlsVerify() {
+        Registry registry = Registry.builder()
+                .withRegistry(tlsRegistry.getRegistry())
+                .withSkipTlsVerify(true)
+                .build();
+
+        List<String> repositories = registry.getRepositories().repositories();
+        assertNotNull(repositories);
+    }
+}

--- a/src/test/java/land/oras/auth/HttpClientTest.java
+++ b/src/test/java/land/oras/auth/HttpClientTest.java
@@ -20,21 +20,39 @@
 
 package land.oras.auth;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import land.oras.exception.OrasException;
+import land.oras.utils.TlsUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
 class HttpClientTest {
+
+    private static final String ROOT_CA_PEM;
+    private static final String ISSUING_CA_PEM;
+
+    static {
+        var rootKeyPair = TlsUtils.generateKeyPair();
+        var rootCaCert = TlsUtils.generateCaCertificate("test-root-ca", rootKeyPair);
+        ROOT_CA_PEM = TlsUtils.toPem(rootCaCert);
+
+        var issuingKeyPair = TlsUtils.generateKeyPair();
+        var issuingCaCert = TlsUtils.generateSignedCertificate(
+                "test-issuing-ca", issuingKeyPair, rootCaCert, rootKeyPair.getPrivate());
+        ISSUING_CA_PEM = TlsUtils.toPem(issuingCaCert);
+    }
 
     @Test
     void testIsSameOriginSame() {
@@ -108,5 +126,114 @@ class HttpClientTest {
         HttpResponse<?> response = mock(HttpResponse.class);
         when(response.statusCode()).thenReturn(200);
         assertFalse(HttpClient.shouldRedirect(response));
+    }
+
+    @Test
+    void whenCaFileFromPathThenSucceed(@TempDir Path tempDir) throws IOException {
+        Path caFile = tempDir.resolve("ca.pem");
+        Files.writeString(caFile, ROOT_CA_PEM);
+        assertDoesNotThrow(() -> HttpClient.Builder.builder().withCaFile(caFile).build());
+    }
+
+    @Test
+    void whenCaFileFromStringThenSucceed(@TempDir Path tempDir) throws IOException {
+        Path caFile = tempDir.resolve("ca.pem");
+        Files.writeString(caFile, ROOT_CA_PEM);
+        assertDoesNotThrow(
+                () -> HttpClient.Builder.builder().withCaFile(caFile.toString()).build());
+    }
+
+    @Test
+    void whenCaFileDoesNotExistThenThrow() {
+        OrasException exception = assertThrows(OrasException.class, () -> HttpClient.Builder.builder()
+                .withCaFile(Path.of("/nonexistent/ca.pem"))
+                .build());
+        assertTrue(exception.getMessage().contains("Unable to configure CA file"));
+    }
+
+    @Test
+    void whenCaFileNotValidCertificateThenThrow(@TempDir Path tempDir) throws IOException {
+        Path caFile = tempDir.resolve("bad.pem");
+        Files.writeString(caFile, "not a certificate");
+        OrasException exception = assertThrows(
+                OrasException.class,
+                () -> HttpClient.Builder.builder().withCaFile(caFile).build());
+        assertTrue(exception.getMessage().contains("Unable to configure CA file"));
+    }
+
+    @Test
+    void whenCaFileIsEmptyThenThrow(@TempDir Path tempDir) throws IOException {
+        Path caFile = Files.createFile(tempDir.resolve("empty.pem"));
+        OrasException exception = assertThrows(
+                OrasException.class,
+                () -> HttpClient.Builder.builder().withCaFile(caFile).build());
+        assertTrue(exception.getMessage().contains("No certificates found in the provided CA file"));
+    }
+
+    @Test
+    void whenCaContentThenSucceed() {
+        assertDoesNotThrow(
+                () -> HttpClient.Builder.builder().withCaContent(ROOT_CA_PEM).build());
+    }
+
+    @Test
+    void whenCaContentIsEmptyThenThrow() {
+        OrasException exception = assertThrows(
+                OrasException.class,
+                () -> HttpClient.Builder.builder().withCaContent("").build());
+        assertTrue(exception.getMessage().contains("No certificates found in the provided CA content"));
+    }
+
+    @Test
+    void whenCaContentNotValidCertificateThenThrow() {
+        OrasException exception = assertThrows(OrasException.class, () -> HttpClient.Builder.builder()
+                .withCaContent("not a certificate")
+                .build());
+        assertTrue(exception.getMessage().contains("Unable to configure CA certificates from content"));
+    }
+
+    @Test
+    void whenBothCaFileAndCaContentConfiguredThenThrow(@TempDir Path tempDir) throws IOException {
+        Path caFile = tempDir.resolve("ca.pem");
+        Files.writeString(caFile, ROOT_CA_PEM);
+        OrasException exception = assertThrows(OrasException.class, () -> HttpClient.Builder.builder()
+                .withCaFile(caFile)
+                .withCaContent(ROOT_CA_PEM)
+                .build());
+        assertTrue(exception.getMessage().contains("Cannot configure both a CA file and CA content"));
+    }
+
+    @Test
+    void whenSkipTlsVerifyAndCaFileThenThrow(@TempDir Path tempDir) throws IOException {
+        Path caFile = tempDir.resolve("ca.pem");
+        Files.writeString(caFile, ROOT_CA_PEM);
+        OrasException exception = assertThrows(OrasException.class, () -> HttpClient.Builder.builder()
+                .withSkipTlsVerify(true)
+                .withCaFile(caFile)
+                .build());
+        assertTrue(exception.getMessage().contains("Cannot combine skipTlsVerify"));
+    }
+
+    @Test
+    void whenSkipTlsVerifyAndCaContentThenThrow() {
+        OrasException exception = assertThrows(OrasException.class, () -> HttpClient.Builder.builder()
+                .withSkipTlsVerify(true)
+                .withCaContent(ROOT_CA_PEM)
+                .build());
+        assertTrue(exception.getMessage().contains("Cannot combine skipTlsVerify"));
+    }
+
+    @Test
+    void whenCaBundleFromFileThenSucceed(@TempDir Path tempDir) throws IOException {
+        Path caFile = tempDir.resolve("ca-bundle.pem");
+        Files.writeString(caFile, ROOT_CA_PEM + ISSUING_CA_PEM);
+        assertDoesNotThrow(() -> HttpClient.Builder.builder().withCaFile(caFile).build());
+    }
+
+    @Test
+    void whenCaBundleFromContentThenSucceed() {
+        assertDoesNotThrow(() -> HttpClient.Builder.builder()
+                .withCaContent(ROOT_CA_PEM + ISSUING_CA_PEM)
+                .build());
     }
 }

--- a/src/test/java/land/oras/utils/TestImages.java
+++ b/src/test/java/land/oras/utils/TestImages.java
@@ -1,0 +1,31 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2026 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.utils;
+
+/**
+ * Container image references used in tests.
+ */
+public final class TestImages {
+
+    public static final String ZOT = "ghcr.io/project-zot/zot-minimal:v2.1.15";
+
+    private TestImages() {}
+}

--- a/src/test/java/land/oras/utils/TlsUtils.java
+++ b/src/test/java/land/oras/utils/TlsUtils.java
@@ -1,0 +1,143 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2026 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.utils;
+
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+/**
+ * Utilities for generating TLS certificates and keys in tests.
+ */
+public final class TlsUtils {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private TlsUtils() {}
+
+    /**
+     * Generate an RSA key pair.
+     * @return The generated key pair
+     */
+    public static KeyPair generateKeyPair() {
+        try {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048, SECURE_RANDOM);
+            return keyPairGenerator.generateKeyPair();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate key pair", e);
+        }
+    }
+
+    /**
+     * Generate a self-signed CA certificate.
+     * @param cn The common name for the CA
+     * @param keyPair The key pair to use
+     * @return The self-signed CA certificate
+     */
+    public static X509Certificate generateCaCertificate(String cn, KeyPair keyPair) {
+        try {
+            X500Name subject = new X500Name("CN=" + cn);
+            Instant now = Instant.now();
+            Date notBefore = Date.from(now);
+            Date notAfter = Date.from(now.plus(365, ChronoUnit.DAYS));
+
+            ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.getPrivate());
+            X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                    subject, BigInteger.valueOf(now.toEpochMilli()), notBefore, notAfter, subject, keyPair.getPublic());
+            builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+
+            return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate CA certificate", e);
+        }
+    }
+
+    /**
+     * Generate a certificate signed by a CA, with Subject Alternative Names for localhost.
+     * @param cn The common name for the certificate
+     * @param keyPair The key pair for the certificate
+     * @param caCert The CA certificate used as issuer
+     * @param caPrivateKey The CA private key used to sign
+     * @return The signed certificate
+     */
+    public static X509Certificate generateSignedCertificate(
+            String cn, KeyPair keyPair, X509Certificate caCert, PrivateKey caPrivateKey) {
+        try {
+            X500Name issuer = new X500Name(caCert.getSubjectX500Principal().getName());
+            X500Name subject = new X500Name("CN=" + cn);
+            Instant now = Instant.now();
+            Date notBefore = Date.from(now);
+            Date notAfter = Date.from(now.plus(365, ChronoUnit.DAYS));
+
+            ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(caPrivateKey);
+            X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                    issuer,
+                    BigInteger.valueOf(now.toEpochMilli() + 1),
+                    notBefore,
+                    notAfter,
+                    subject,
+                    keyPair.getPublic());
+            builder.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(new GeneralName[] {
+                new GeneralName(GeneralName.dNSName, "localhost"), new GeneralName(GeneralName.iPAddress, "127.0.0.1")
+            }));
+
+            return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate signed certificate", e);
+        }
+    }
+
+    /**
+     * Convert a security object (certificate, private key, etc.) to PEM format.
+     * @param object The object to convert
+     * @return The PEM-encoded string
+     */
+    public static String toPem(Object object) {
+        try {
+            StringWriter writer = new StringWriter();
+            try (JcaPEMWriter pemWriter = new JcaPEMWriter(writer)) {
+                pemWriter.writeObject(object);
+            }
+            return writer.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert to PEM", e);
+        }
+    }
+}

--- a/src/test/java/land/oras/utils/ZotBaseContainer.java
+++ b/src/test/java/land/oras/utils/ZotBaseContainer.java
@@ -1,0 +1,82 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2026 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.utils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.MountableFile;
+
+@NullMarked
+public abstract class ZotBaseContainer<T extends ZotBaseContainer<T>> extends GenericContainer<T> {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    static final int ZOT_PORT = 5000;
+
+    protected ZotBaseContainer() {
+        super(TestImages.ZOT);
+        addExposedPort(ZOT_PORT);
+    }
+
+    /**
+     * Get the registry host:port
+     * @return The registry URL
+     */
+    public String getRegistry() {
+        return getHost() + ":" + getMappedPort(ZOT_PORT);
+    }
+
+    @SuppressWarnings("unchecked")
+    public T withFollowOutput() {
+        followOutput(new Slf4jLogConsumer(log));
+        return (T) this;
+    }
+
+    /**
+     * Write a Zot config JSON to a temp file and copy it into the container.
+     * @param configJson The JSON config content
+     */
+    protected void writeConfig(String configJson) {
+        try {
+            Path configFile = Files.createTempFile("zot-config", ".json");
+            Files.writeString(configFile, configJson);
+            withCopyFileToContainer(
+                    MountableFile.forHostPath(configFile.toAbsolutePath().toString()), "/etc/zot/config.json");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write Zot config", e);
+        }
+    }
+
+    /**
+     * Copy a host file into the container.
+     * @param hostPath The path on the host
+     * @param containerPath The path inside the container
+     */
+    protected void copyFileToContainer(Path hostPath, String containerPath) {
+        withCopyFileToContainer(
+                MountableFile.forHostPath(hostPath.toAbsolutePath().toString()), containerPath);
+    }
+}

--- a/src/test/java/land/oras/utils/ZotContainer.java
+++ b/src/test/java/land/oras/utils/ZotContainer.java
@@ -23,40 +23,26 @@ package land.oras.utils;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.jspecify.annotations.NullMarked;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.MountableFile;
 
 @NullMarked
-public class ZotContainer extends GenericContainer<ZotContainer> {
-
-    /**
-     * Logger
-     */
-    private Logger LOG = LoggerFactory.getLogger(ZotContainer.class);
+public class ZotContainer extends ZotBaseContainer<ZotContainer> {
 
     // myuser:mypass
     public static final String AUTH_STRING = "myuser:$2y$05$M1VYs6EzFkXBmuS.BrIreObAnJcWCgzSPeT9/Rh3aVEqTqtSL8XN.";
-    public static final int ZOT_PORT = 5000;
 
     /**
-     * Create a new registry container
+     * Create a new Zot registry container with htpasswd authentication.
      */
     public ZotContainer() {
-        super("ghcr.io/project-zot/zot-linux-amd64:v2.1.15");
-        addExposedPort(ZOT_PORT);
         setWaitStrategy(Wait.forHttp("/v2/_catalog").forPort(ZOT_PORT).forStatusCode(401));
 
         try {
             // Auth file
             Path authFile = Files.createTempFile("auth", ".htpasswd");
             Files.writeString(authFile, AUTH_STRING);
+            copyFileToContainer(authFile, "/etc/zot/auth.htpasswd");
 
-            // Zot config file
-            Path configFile = Files.createTempFile("zot-config", ".json");
             // language=JSON
             String configJson =
                     """
@@ -73,32 +59,12 @@ public class ZotContainer extends GenericContainer<ZotContainer> {
                         "search": { "enable": true }
                       }
                     }
-              """
+                    """
                             .formatted(ZOT_PORT);
-
-            Files.writeString(configFile, configJson);
-
-            // Copy it into the container
-            withCopyFileToContainer(
-                    MountableFile.forHostPath(authFile.toAbsolutePath().toString()), "/etc/zot/auth.htpasswd");
-            withCopyFileToContainer(
-                    MountableFile.forHostPath(configFile.toAbsolutePath().toString()), "/etc/zot/config.json");
+            writeConfig(configJson);
 
         } catch (Exception e) {
             throw new RuntimeException("Failed to create auth.htpasswd", e);
         }
-    }
-
-    /**
-     * Get the registry URL
-     * @return The registry URL
-     */
-    public String getRegistry() {
-        return getHost() + ":" + getMappedPort(ZOT_PORT);
-    }
-
-    public ZotContainer withFollowOutput() {
-        followOutput(new Slf4jLogConsumer(LOG));
-        return this;
     }
 }

--- a/src/test/java/land/oras/utils/ZotTlsContainer.java
+++ b/src/test/java/land/oras/utils/ZotTlsContainer.java
@@ -1,0 +1,113 @@
+/*-
+ * =LICENSE=
+ * ORAS Java SDK
+ * ===
+ * Copyright (C) 2024 - 2026 ORAS
+ * ===
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
+
+package land.oras.utils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import org.jspecify.annotations.NullMarked;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+@NullMarked
+public class ZotTlsContainer extends ZotBaseContainer<ZotTlsContainer> {
+
+    private final Path caCertPath;
+
+    /**
+     * Create a new TLS-enabled Zot registry container.
+     * Generates a self-signed CA and server certificate at construction time.
+     */
+    public ZotTlsContainer() {
+        setWaitStrategy(Wait.forHttps("/v2/_catalog")
+                .forPort(ZOT_PORT)
+                .forStatusCode(200)
+                .allowInsecure());
+
+        try {
+            Path certDir = Files.createTempDirectory("zot-tls");
+            caCertPath = certDir.resolve("ca.pem");
+            Path serverCertPath = certDir.resolve("server.pem");
+            Path serverKeyPath = certDir.resolve("server-key.pem");
+
+            // Generate CA
+            KeyPair caKeyPair = TlsUtils.generateKeyPair();
+            X509Certificate caCert = TlsUtils.generateCaCertificate("test-zot-ca", caKeyPair);
+
+            // Generate server certificate signed by CA
+            KeyPair serverKeyPair = TlsUtils.generateKeyPair();
+            X509Certificate serverCert =
+                    TlsUtils.generateSignedCertificate("localhost", serverKeyPair, caCert, caKeyPair.getPrivate());
+
+            // Write PEM files
+            Files.writeString(caCertPath, TlsUtils.toPem(caCert));
+            Files.writeString(serverCertPath, TlsUtils.toPem(serverCert));
+            Files.writeString(serverKeyPath, TlsUtils.toPem(serverKeyPair.getPrivate()));
+
+            copyFileToContainer(serverCertPath, "/etc/zot/server.pem");
+            copyFileToContainer(serverKeyPath, "/etc/zot/server-key.pem");
+
+            // language=JSON
+            String configJson =
+                    """
+                    {
+                      "storage": { "rootDirectory": "/var/lib/registry" },
+                      "http": {
+                        "address": "0.0.0.0",
+                        "port": %s,
+                        "tls": {
+                          "cert": "/etc/zot/server.pem",
+                          "key": "/etc/zot/server-key.pem"
+                        }
+                      },
+                      "extensions": {
+                        "search": { "enable": true }
+                      }
+                    }
+                    """
+                            .formatted(ZOT_PORT);
+            writeConfig(configJson);
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set up TLS for Zot container", e);
+        }
+    }
+
+    /**
+     * Get the path to the CA certificate PEM file
+     * @return The CA certificate path
+     */
+    public Path getCaCertPath() {
+        return caCertPath;
+    }
+
+    /**
+     * Get the CA certificate PEM content as a string
+     * @return The CA certificate content
+     */
+    public String getCaCertContent() {
+        try {
+            return Files.readString(caCertPath);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read CA certificate", e);
+        }
+    }
+}

--- a/src/test/java/land/oras/utils/ZotUnsecureContainer.java
+++ b/src/test/java/land/oras/utils/ZotUnsecureContainer.java
@@ -20,74 +20,33 @@
 
 package land.oras.utils;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.jspecify.annotations.NullMarked;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.MountableFile;
 
 @NullMarked
-public class ZotUnsecureContainer extends GenericContainer<ZotUnsecureContainer> {
+public class ZotUnsecureContainer extends ZotBaseContainer<ZotUnsecureContainer> {
 
     /**
-     * Logger
-     */
-    private Logger LOG = LoggerFactory.getLogger(ZotUnsecureContainer.class);
-
-    // myuser:mypass
-    public static final int ZOT_PORT = 5001;
-
-    /**
-     * Create a new registry container
+     * Create a new unsecure Zot registry container (HTTP, no auth).
      */
     public ZotUnsecureContainer() {
-        super("ghcr.io/project-zot/zot-linux-amd64:v2.1.15");
-        addExposedPort(ZOT_PORT);
         setWaitStrategy(Wait.forHttp("/v2/_catalog").forPort(ZOT_PORT).forStatusCode(200));
 
-        try {
-            // Zot config file
-            Path configFile = Files.createTempFile("zot-config", ".json");
-            String configJson =
-                    """
-                    {
-                      "storage": { "rootDirectory": "/var/lib/registry" },
-                      "http": {
-                        "address": "0.0.0.0",
-                        "port": %s
-                      },
-                      "extensions": {
-                        "search": { "enable": true }
-                      }
-                    }
-              """
-                            .formatted(ZOT_PORT);
-
-            Files.writeString(configFile, configJson);
-
-            // Copy it into the container
-            withCopyFileToContainer(
-                    MountableFile.forHostPath(configFile.toAbsolutePath().toString()), "/etc/zot/config.json");
-
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to create auth.htpasswd", e);
-        }
-    }
-
-    /**
-     * Get the registry URL
-     * @return The registry URL
-     */
-    public String getRegistry() {
-        return getHost() + ":" + getMappedPort(ZOT_PORT);
-    }
-
-    public ZotUnsecureContainer withFollowOutput() {
-        followOutput(new Slf4jLogConsumer(LOG));
-        return this;
+        // language=JSON
+        String configJson =
+                """
+                {
+                  "storage": { "rootDirectory": "/var/lib/registry" },
+                  "http": {
+                    "address": "0.0.0.0",
+                    "port": %s
+                  },
+                  "extensions": {
+                    "search": { "enable": true }
+                  }
+                }
+                """
+                        .formatted(ZOT_PORT);
+        writeConfig(configJson);
     }
 }

--- a/updatecli/updatecli.d/zot.yaml
+++ b/updatecli/updatecli.d/zot.yaml
@@ -29,26 +29,17 @@ conditions:
     name: zot image must exists
     kind: dockerimage
     spec:
-      image: ghcr.io/project-zot/zot-linux-amd64
+      image: ghcr.io/project-zot/zot-minimal
 
 targets:
-  updateZotContainer:
-    name: "Update the value in the ZotContainer.java file"
+  updateZotImages:
+    name: "Update the value in the TestImages.java file"
     kind: file
     sourceid: zotLatestVersion
     spec:
-      file: src/test/java/land/oras/utils/ZotContainer.java
-      matchPattern: "ghcr.io/project-zot/zot-linux-amd64:v(\\d.\\d.\\d{1,2})"
-      replacePattern: 'ghcr.io/project-zot/zot-linux-amd64:{{ source "zotLatestVersion" }}'
-    scmid: default
-  updateZotUnsecureContainer:
-    name: "Update the value in the ZotUnsecureContainer.java file"
-    kind: file
-    sourceid: zotLatestVersion
-    spec:
-      file: src/test/java/land/oras/utils/ZotUnsecureContainer.java
-      matchPattern: "ghcr.io/project-zot/zot-linux-amd64:v(\\d.\\d.\\d{1,2})"
-      replacePattern: 'ghcr.io/project-zot/zot-linux-amd64:{{ source "zotLatestVersion" }}'
+      file: src/test/java/land/oras/utils/TestImages.java
+      matchPattern: "ghcr.io/project-zot/zot-minimal:v(\\d.\\d.\\d{1,2})"
+      replacePattern: 'ghcr.io/project-zot/zot-minimal:{{ source "zotLatestVersion" }}'
     scmid: default
 
 actions:


### PR DESCRIPTION
### Description

- Introduce `.withCaFile()` and `.withCaContent()` method to `Registry` and `HttpClient` to provide custom CA certificates to be used for establishing a TLS connection with an OCI registry.
- Refactor `HttpClient.Builder` to ensure correct and consistent state when using multiple TLS-related methods like `.withSkipTlsVerify()`, `.withCaFile()`, and `.withCaContent()`.
- Add integration tests for TLS-related operations with a Zot OCI registry. Introduce a `ZotBaseContainer` class to consolidate common logic rather than duplicating code in the newly added `ZotTlsContainer` for TLS-related tests.

Fixes gh-670

### Testing done

- Added unit tests covering the new feature.
- Added integration tests covering the new feature.

### Submitter checklist
- [X] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [X] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
