### PR TITLE
Use unique metric name for HTTP requests

### DIFF
--- a/src/main/java/land/oras/utils/Const.java
+++ b/src/main/java/land/oras/utils/Const.java
@@ -449,7 +449,7 @@ public final class Const {
     /**
      * Metric name for HTTP request
      */
-    public static final String METRIC_HTTP_REQUESTS = "http.client.requests";
+    public static final String METRIC_HTTP_REQUESTS = "land.oras.http.client.requests";
 
     /**
      * Metric name for token refresh duration


### PR DESCRIPTION
Conflict with Quarkus for example

```
java.lang.IllegalArgumentException: Prometheus requires that all meters with the same name have the  │
│ same set of tag keys. There is already an existing meter named 'http_client_requests_seconds' containing tag keys [clientName, method, outcome, status, uri]. The meter you are attempting to register has ke │
│ ys [host, method, status]. 
```

### Description

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
