### PR TITLE
Regression when file already exists when exploding archive

### DIFF
--- a/src/main/java/land/oras/utils/ArchiveUtils.java
+++ b/src/main/java/land/oras/utils/ArchiveUtils.java
@@ -405,7 +405,8 @@ public final class ArchiveUtils {
                             Files.createDirectories(outputPath.getParent());
                             try (OutputStream out = Files.newOutputStream(
                                     outputPath,
-                                    StandardOpenOption.CREATE_NEW,
+                                    StandardOpenOption.CREATE,
+                                    StandardOpenOption.TRUNCATE_EXISTING,
                                     StandardOpenOption.WRITE,
                                     LinkOption.NOFOLLOW_LINKS)) {
                                 zais.transferTo(out);
@@ -458,7 +459,8 @@ public final class ArchiveUtils {
                         } else {
                             try (OutputStream out = Files.newOutputStream(
                                     outputPath,
-                                    StandardOpenOption.CREATE_NEW,
+                                    StandardOpenOption.CREATE,
+                                    StandardOpenOption.TRUNCATE_EXISTING,
                                     StandardOpenOption.WRITE,
                                     LinkOption.NOFOLLOW_LINKS)) {
                                 tais.transferTo(out);

--- a/src/test/java/land/oras/utils/ArchiveUtilsTest.java
+++ b/src/test/java/land/oras/utils/ArchiveUtilsTest.java
@@ -369,4 +369,62 @@ class ArchiveUtilsTest {
         assertThrows(OrasException.class, () -> ArchiveUtils.untar(mtar, target));
         assertFalse(Files.exists(escapeFile), "Symlink-target escape must not create a file outside target");
     }
+
+    @Test
+    void shouldUntarOverwriteExistingFiles(@TempDir Path tmp) throws IOException {
+        Path target = tmp.resolve("output");
+        Files.createDirectories(target);
+
+        byte[] firstContent = "first".getBytes();
+        byte[] secondContent = "second-overwritten".getBytes();
+
+        Path tar1 = tmp.resolve("first.tar");
+        try (TarArchiveOutputStream tout = new TarArchiveOutputStream(Files.newOutputStream(tar1))) {
+            TarArchiveEntry e = new TarArchiveEntry("file.txt");
+            e.setSize(firstContent.length);
+            tout.putArchiveEntry(e);
+            tout.write(firstContent);
+            tout.closeArchiveEntry();
+        }
+        ArchiveUtils.untar(tar1, target);
+        assertEquals("first", Files.readString(target.resolve("file.txt")));
+
+        Path tar2 = tmp.resolve("second.tar");
+        try (TarArchiveOutputStream tout = new TarArchiveOutputStream(Files.newOutputStream(tar2))) {
+            TarArchiveEntry e = new TarArchiveEntry("file.txt");
+            e.setSize(secondContent.length);
+            tout.putArchiveEntry(e);
+            tout.write(secondContent);
+            tout.closeArchiveEntry();
+        }
+        ArchiveUtils.untar(tar2, target);
+        assertEquals("second-overwritten", Files.readString(target.resolve("file.txt")));
+    }
+
+    @Test
+    void shouldUnzipOverwriteExistingFiles(@TempDir Path tmp) throws IOException {
+        Path target = tmp.resolve("output");
+        Files.createDirectories(target);
+
+        byte[] firstContent = "first".getBytes();
+        byte[] secondContent = "second-overwritten".getBytes();
+
+        Path zip1 = tmp.resolve("first.zip");
+        try (java.util.zip.ZipOutputStream zout = new java.util.zip.ZipOutputStream(Files.newOutputStream(zip1))) {
+            zout.putNextEntry(new java.util.zip.ZipEntry("file.txt"));
+            zout.write(firstContent);
+            zout.closeEntry();
+        }
+        ArchiveUtils.unzip(zip1, target);
+        assertEquals("first", Files.readString(target.resolve("file.txt")));
+
+        Path zip2 = tmp.resolve("second.zip");
+        try (java.util.zip.ZipOutputStream zout = new java.util.zip.ZipOutputStream(Files.newOutputStream(zip2))) {
+            zout.putNextEntry(new java.util.zip.ZipEntry("file.txt"));
+            zout.write(secondContent);
+            zout.closeEntry();
+        }
+        ArchiveUtils.unzip(zip2, target);
+        assertEquals("second-overwritten", Files.readString(target.resolve("file.txt")));
+    }
 }


### PR DESCRIPTION
Last security fix cause a regression when exploding archive. Previous any existing files where replaced, which is not the case now.

Fix it and add a test to prevent future regression

This cause issue on Jenkins (for example getting library artifacty)

```
26-05-28T05:14:24.330Z] 	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:94)
[2026-05-28T05:14:24.330Z] 	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
[2026-05-28T05:14:24.330Z] 	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
[2026-05-28T05:14:24.330Z] 	at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:213)
[2026-05-28T05:14:24.330Z] 	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:244)
[2026-05-28T05:14:24.330Z] 	at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:426)
[2026-05-28T05:14:24.330Z] 	at java.base/java.nio.file.Files.newOutputStream(Files.java:215)
[2026-05-28T05:14:24.330Z] 	at PluginClassLoader for oras-java-api//land.oras.utils.ArchiveUtils.untar(ArchiveUtils.java:459)
[2026-05-28T05:14:24.330Z] Caused: land.oras.exception.OrasException: Failed to extract tar.gz file
[2026-05-28T05:14:24.330Z] 	at PluginClassLoader for oras-java-api//land.oras.utils.ArchiveUtils.untar(ArchiveUtils.java:474)
[2026-05-28T05:14:24.330Z] 	at PluginClassLoader for oras-java-api//land.oras.Registry.pullLayer(Registry.java:1109)
[2026-05-28T05:14:24.330Z] 	at PluginClassLoader for oras-java-api//land.oras.Registry.lambda$pullArtifact$4(Registry.java:550)
[2026-05-28T05:14:24.330Z] 	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1825)
[2026-05-28T05:14:24.330Z] Caused: java.util.concurrent.CompletionException
```

### Description

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
