### PR TITLE
Add two constants to running container media type

### DIFF
--- a/src/main/java/land/oras/utils/Const.java
+++ b/src/main/java/land/oras/utils/Const.java
@@ -195,6 +195,16 @@ public final class Const {
     public static final String DEFAULT_MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";
 
     /**
+     * Media type for config of running container
+     */
+    public static final String CONFIG_RUNNING_CONTAINER_MEDIA_TYPE = "application/vnd.oci.image.config.v1+json";
+
+    /**
+     * Media type for config of running docker
+     */
+    public static final String CONFIG_RUNNING_DOCKER_MEDIA_TYPE = "application/vnd.docker.container.image.v1+json";
+
+    /**
      * The default accept type for the manifest
      */
     public static final String MANIFEST_ACCEPT_TYPE = "%s, %s, %s, %s, %s"

--- a/src/test/java/land/oras/utils/ConstTest.java
+++ b/src/test/java/land/oras/utils/ConstTest.java
@@ -36,5 +36,7 @@ class ConstTest {
         assertEquals("org.opencontainers.image.revision", Const.ANNOTATION_REVISION);
         assertEquals("org.opencontainers.image.created", Const.ANNOTATION_CREATED);
         assertEquals("org.opencontainers.image.ref.name", Const.ANNOTATION_REF);
+        assertEquals("application/vnd.oci.image.config.v1+json", Const.CONFIG_RUNNING_CONTAINER_MEDIA_TYPE);
+        assertEquals("application/vnd.docker.container.image.v1+json", Const.CONFIG_RUNNING_DOCKER_MEDIA_TYPE);
     }
 }


### PR DESCRIPTION
### Description

Add two constants to running container media type

### Testing done

mvn clean install

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
