### PR TITLE
Handle null tag when digest is set without tag

### DIFF
--- a/src/main/java/land/oras/ContainerRef.java
+++ b/src/main/java/land/oras/ContainerRef.java
@@ -646,15 +646,18 @@ public final class ContainerRef extends Ref<ContainerRef> {
 
     @Override
     public String toString() {
+        String ref = digest != null ? "@" + digest : (tag != null ? ":" + tag : "");
+
         if (isUnqualified()) {
             if (namespace != null && !namespace.isEmpty()) {
-                return "%s/%s:%s%s".formatted(namespace, repository, tag, digest != null ? "@" + digest : "");
+                return "%s/%s%s".formatted(namespace, repository, ref);
             }
-            return "%s:%s%s".formatted(repository, tag, digest != null ? "@" + digest : "");
+            return "%s%s".formatted(repository, ref);
         }
+
         if (namespace != null && !namespace.isEmpty()) {
-            return "%s/%s/%s:%s%s".formatted(registry, namespace, repository, tag, digest != null ? "@" + digest : "");
+            return "%s/%s/%s%s".formatted(registry, namespace, repository, ref);
         }
-        return "%s/%s:%s%s".formatted(registry, repository, tag, digest != null ? "@" + digest : "");
+        return "%s/%s%s".formatted(registry, repository, ref);
     }
 }

--- a/src/test/java/land/oras/ContainerRefTest.java
+++ b/src/test/java/land/oras/ContainerRefTest.java
@@ -452,7 +452,7 @@ class ContainerRefTest {
     @Test
     void testToStringDefault() {
         ContainerRef containerRef1 = ContainerRef.parse("alpine1@sha256:1234567890abcdef");
-        assertEquals("alpine1:latest@sha256:1234567890abcdef", containerRef1.toString());
+        assertEquals("alpine1@sha256:1234567890abcdef", containerRef1.toString());
     }
 
     @Test

--- a/src/test/java/land/oras/auth/RegistryConfTest.java
+++ b/src/test/java/land/oras/auth/RegistryConfTest.java
@@ -335,10 +335,8 @@ class RegistryConfTest {
         ContainerRef rewrittenDigest = conf.rewriteForMirror(digestOnly, mirror);
         assertFalse(rewrittenDigest.toString().contains(":null"), "Tag must not appear as ':null'");
         assertTrue(rewrittenDigest.toString().contains("sha256:"), "Digest must be preserved in rewritten ref");
-        // ContainerRef.parse() defaults the tag to "latest" when omitted, so the rewritten ref
-        // carries both the digest and the default tag — the digest still drives resolution.
         assertEquals(
-                "mirror.example.com/library/alpine:latest@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                "mirror.example.com/library/alpine@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
                 rewrittenDigest.toString());
     }
 


### PR DESCRIPTION
### Description

The test was badly implemented and asserting 'latest' tag wich is the default when not digest is specified

### Testing done

mvn clean install

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
