### PR TITLE
Remove env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,6 @@ The SDK reads configuration from the following locations, in order (later entrie
 3. `$HOME/.config/containers/registries.conf`
 4. `$HOME/.config/containers/registries.conf.d/*.conf` (alphabetical)
 
-Set the `CONTAINERS_REGISTRIES_CONF` environment variable to use a single file exclusively.
-
 ### Supported features
 
 ```toml
@@ -313,9 +311,8 @@ Skopeo and Buildah.
 
 The policy is loaded from the following locations, in order (the first that exists wins):
 
-1. the path in the `CONTAINERS_POLICY` environment variable (if set)
-2. `$HOME/.config/containers/policy.json`
-3. `/etc/containers/policy.json`
+1. `$HOME/.config/containers/policy.json`
+2. `/etc/containers/policy.json`
 
 If no policy file is found, an **accept-all** policy is used. You can also set it explicitly:
 

--- a/src/main/java/land/oras/auth/RegistriesConf.java
+++ b/src/main/java/land/oras/auth/RegistriesConf.java
@@ -90,23 +90,17 @@ public class RegistriesConf {
 
     /**
      * Create a new RegistriesConf instance by loading configuration from standard paths.
-     * If the {@code CONTAINERS_REGISTRIES_CONF} environment variable is set it is used exclusively.
-     * Otherwise, the user-local config (under {@code $HOME}) is tried first, then {@code /etc/containers/registries.conf}.
+     * The user-local config (under {@code $HOME}) is tried first, then {@code /etc/containers/registries.conf}.
      *
      * @return A new RegistriesConf instance.
      */
     public static RegistriesConf newConf() {
-        String containersRegistriesConf = System.getenv("CONTAINERS_REGISTRIES_CONF");
-        if (containersRegistriesConf != null) {
-            LOG.debug("Using registries config from CONTAINERS_REGISTRIES_CONF: {}", containersRegistriesConf);
-            return newConf(List.of(Path.of(containersRegistriesConf)));
-        }
         return newConf(defaultConfPaths());
     }
 
     /**
-     * Returns the ordered list of registries.conf paths to load and merge when {@code CONTAINERS_REGISTRIES_CONF}
-     * is not set. Follows the containers/image search order:
+     * Returns the ordered list of registries.conf paths to load and merge.
+     * Follows the containers/image search order:
      * <ol>
      *   <li>{@code /etc/containers/registries.conf}</li>
      *   <li>{@code /etc/containers/registries.conf.d/*.conf} (alpha-numerical order)</li>

--- a/src/main/java/land/oras/policy/ContainersPolicy.java
+++ b/src/main/java/land/oras/policy/ContainersPolicy.java
@@ -76,18 +76,12 @@ public class ContainersPolicy {
     }
 
     /**
-     * Load the containers policy from the standard locations and honoring CONTAINERS_POLICY env var if set.
+     * Load the containers policy from the standard locations.
      *
      * @return a {@link ContainersPolicy} instance.
      * @throws OrasException if a candidate file exists but cannot be read or parsed.
      */
     public static ContainersPolicy newPolicy() {
-        String envPath = System.getenv("CONTAINERS_POLICY");
-        if (envPath != null) {
-            LOG.debug("Using containers policy from CONTAINERS_POLICY: {}", envPath);
-            return newPolicy(Path.of(envPath));
-        }
-
         for (Path candidate : defaultPolicyPaths()) {
             LOG.debug("Checking for containers policy at: {}", candidate);
             if (Files.exists(candidate)) {

--- a/src/test/java/land/oras/TestUtils.java
+++ b/src/test/java/land/oras/TestUtils.java
@@ -95,7 +95,6 @@ public final class TestUtils {
         synchronized (TestUtils.class) {
             new EnvironmentVariables()
                     .set("HOME", homeDir.toAbsolutePath().toString())
-                    .remove("CONTAINERS_REGISTRIES_CONF")
                     .execute(() -> {
                         try {
                             action.run();

--- a/src/test/java/land/oras/auth/RegistriesConfTest.java
+++ b/src/test/java/land/oras/auth/RegistriesConfTest.java
@@ -22,7 +22,6 @@ package land.oras.auth;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import land.oras.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -129,69 +128,10 @@ class RegistriesConfTest {
     @Test
     void shouldFallBackToGlobalPathWhenHomeIsAbsent() throws Exception {
         synchronized (TestUtils.class) {
-            new EnvironmentVariables()
-                    .remove("HOME")
-                    .remove("CONTAINERS_REGISTRIES_CONF")
-                    .execute(() -> {
-                        RegistriesConf conf = RegistriesConf.newConf();
-                        assertNotNull(conf);
-                    });
-        }
-    }
-
-    @Test
-    void shouldUseContainersRegistriesConfWhenSet(@TempDir Path customDir) throws Exception {
-        // language=toml
-        String customContent =
-                """
-        unqualified-search-registries = ["quay.io"]
-
-        [aliases]
-        "busybox"="quay.io/library/busybox"
-        """;
-        Path customFile = customDir.resolve("registries.conf");
-        Files.writeString(customFile, customContent);
-
-        synchronized (TestUtils.class) {
-            new EnvironmentVariables()
-                    .set(
-                            "CONTAINERS_REGISTRIES_CONF",
-                            customFile.toAbsolutePath().toString())
-                    .execute(() -> {
-                        RegistriesConf conf = RegistriesConf.newConf();
-                        assertNotNull(conf);
-                        assertEquals(1, conf.getUnqualifiedRegistries().size());
-                        assertEquals("quay.io", conf.getUnqualifiedRegistries().get(0));
-                        assertTrue(conf.hasAlias("busybox"));
-                        assertEquals(
-                                "quay.io/library/busybox", conf.getAliases().get("busybox"));
-                    });
-        }
-    }
-
-    @Test
-    void containersRegistriesConfTakesPrecedenceOverHome(@TempDir Path customDir) throws Exception {
-        // language=toml
-        String customContent = """
-        unqualified-search-registries = ["custom.io"]
-        """;
-        Path customFile = customDir.resolve("registries.conf");
-        Files.writeString(customFile, customContent);
-
-        synchronized (TestUtils.class) {
-            new EnvironmentVariables()
-                    .set(
-                            "CONTAINERS_REGISTRIES_CONF",
-                            customFile.toAbsolutePath().toString())
-                    .set("HOME", homeDir.toAbsolutePath().toString())
-                    .execute(() -> {
-                        RegistriesConf conf = RegistriesConf.newConf();
-                        // Must reflect the custom file, not the HOME-based one (which has "docker.io")
-                        assertEquals(1, conf.getUnqualifiedRegistries().size());
-                        assertEquals(
-                                "custom.io", conf.getUnqualifiedRegistries().get(0));
-                        assertFalse(conf.hasAlias("alpine"));
-                    });
+            new EnvironmentVariables().remove("HOME").execute(() -> {
+                RegistriesConf conf = RegistriesConf.newConf();
+                assertNotNull(conf);
+            });
         }
     }
 }

--- a/src/test/java/land/oras/policy/ContainersPolicyTest.java
+++ b/src/test/java/land/oras/policy/ContainersPolicyTest.java
@@ -210,30 +210,11 @@ class ContainersPolicyTest {
 
     @Test
     @Execution(ExecutionMode.SAME_THREAD)
-    void loadsFromContainersPolicyEnvVar(@TempDir Path dir) throws Exception {
-        Path policyPath = dir.resolve("policy.json");
-        // language=json
-        Files.writeString(policyPath, """
-                {"default": [{"type": "reject"}]}
-                """);
-
-        new EnvironmentVariables()
-                .set("CONTAINERS_POLICY", policyPath.toAbsolutePath().toString())
-                .set("HOME", dir.toAbsolutePath().toString())
-                .execute(() -> {
-                    ContainersPolicy policy = ContainersPolicy.newPolicy();
-                    assertFalse(policy.isAllowed(Transport.DOCKER, "docker.io/library/nginx"));
-                });
-    }
-
-    @Test
-    @Execution(ExecutionMode.SAME_THREAD)
     void fallsBackToAcceptAllWhenNoPolicyFileFound(@TempDir Path emptyHome) throws Exception {
         // Use a home dir that has no policy.json and ensure /etc/containers/policy.json is skipped
         // by pointing both to a dir we control (emptyHome has no policy.json)
         new EnvironmentVariables()
                 .set("HOME", emptyHome.toAbsolutePath().toString())
-                .remove("CONTAINERS_POLICY")
                 .execute(() -> {
                     ContainersPolicy policy = ContainersPolicy.newPolicy();
                     assertNotNull(policy);


### PR DESCRIPTION
### Description

Remove en var support

Not sucure. Allow anyone to control the path of config files

### Testing done

mvn clean install

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
