### PR TITLE
Key `TokenCache` entries by auth provider identity, not just scope

### DIFF
--- a/src/main/java/land/oras/auth/AbstractUsernamePasswordProvider.java
+++ b/src/main/java/land/oras/auth/AbstractUsernamePasswordProvider.java
@@ -74,4 +74,9 @@ public abstract sealed class AbstractUsernamePasswordProvider implements AuthPro
     public AuthScheme getAuthScheme() {
         return AuthScheme.BASIC;
     }
+
+    @Override
+    public String getIdentity(ContainerRef registry) {
+        return "BASIC:" + username;
+    }
 }

--- a/src/main/java/land/oras/auth/AuthProvider.java
+++ b/src/main/java/land/oras/auth/AuthProvider.java
@@ -42,4 +42,14 @@ public interface AuthProvider {
      * @return The authentication scheme
      */
     AuthScheme getAuthScheme();
+
+    /**
+     * Get an opaque identity marker for the credentials this provider resolves for the given registry. This marker is
+     * used to key {@link TokenCache} entries alongside the requested {@link Scopes}
+     * @param registry The registry
+     * @return A non-null identity marker
+     */
+    default String getIdentity(ContainerRef registry) {
+        return getAuthScheme().name();
+    }
 }

--- a/src/main/java/land/oras/auth/AuthStoreAuthenticationProvider.java
+++ b/src/main/java/land/oras/auth/AuthStoreAuthenticationProvider.java
@@ -64,4 +64,10 @@ public final class AuthStoreAuthenticationProvider implements AuthProvider {
     public AuthScheme getAuthScheme() {
         return AuthScheme.BASIC;
     }
+
+    @Override
+    public String getIdentity(ContainerRef registry) {
+        Credential credential = authStore.get(registry);
+        return credential == null ? "BASIC:anonymous" : "BASIC:" + credential.username();
+    }
 }

--- a/src/main/java/land/oras/auth/BearerTokenProvider.java
+++ b/src/main/java/land/oras/auth/BearerTokenProvider.java
@@ -20,6 +20,9 @@
 
 package land.oras.auth;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import land.oras.ContainerRef;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -83,5 +86,26 @@ public final class BearerTokenProvider implements AuthProvider {
     @Override
     public AuthScheme getAuthScheme() {
         return AuthScheme.BEARER;
+    }
+
+    @Override
+    public String getIdentity(ContainerRef registry) {
+        if (token == null) {
+            return "BEARER:none";
+        }
+        return "BEARER:" + fingerprint(token.token());
+    }
+
+    private static String fingerprint(String secret) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(secret.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 6; i++) {
+                sb.append(String.format("%02x", hash[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/src/main/java/land/oras/auth/HttpClient.java
+++ b/src/main/java/land/oras/auth/HttpClient.java
@@ -694,8 +694,10 @@ public final class HttpClient {
                     case "DELETE" -> scopes.withAddedRegistryScopes(Scope.DELETE);
                     default -> throw new OrasException("Unsupported HTTP method: " + method);
                 };
+        newScopes = newScopes.withIdentity(authProvider.getIdentity(containerRef));
         LOG.debug("Existing scopes: {}", scopes.getScopes());
         LOG.debug("New scopes: {}", newScopes.getScopes());
+        LOG.debug("With identity {}", newScopes.getIdentity());
 
         int maxAttempts = retryEnabled ? this.maxRetries : 1;
 

--- a/src/main/java/land/oras/auth/Scopes.java
+++ b/src/main/java/land/oras/auth/Scopes.java
@@ -49,25 +49,37 @@ public final class Scopes {
     private final ContainerRef containerRef;
 
     /**
-     * Private constructor
+     * Opaque identity marker for the {@link AuthProvider} that resolved (or will resolve) this scope. Two
+     * {@link AuthProvider} instances that are not equivalent
+     */
+    private final @Nullable String identity;
+
+    /**
+     * Canonical private constructor
      * @param containerRef The container reference
      * @param service The service
+     * @param identity The auth provider identity marker
      * @param scopes The scopes
      */
-    private Scopes(ContainerRef containerRef, @Nullable String service, Scope... scopes) {
-        this(containerRef, service, ScopeUtils.appendRepositoryScope(List.of(), containerRef, scopes));
+    private Scopes(
+            ContainerRef containerRef, @Nullable String service, @Nullable String identity, List<String> scopes) {
+        this.containerRef = containerRef;
+        this.service = service;
+        this.identity = identity;
+        this.scopes = scopes;
     }
 
     /**
-     * Private constructor
+     * Return Scopes with new scopes
      * @param containerRef The container reference
      * @param service The service
+     * @param identity The auth provider identity marker
      * @param scopes The scopes
      */
-    private Scopes(ContainerRef containerRef, @Nullable String service, List<String> scopes) {
-        this.containerRef = containerRef;
-        this.service = service;
-        this.scopes = scopes;
+    private static Scopes withRepositoryScopes(
+            ContainerRef containerRef, @Nullable String service, @Nullable String identity, Scope... scopes) {
+        return new Scopes(
+                containerRef, service, identity, ScopeUtils.appendRepositoryScope(List.of(), containerRef, scopes));
     }
 
     /**
@@ -77,7 +89,7 @@ public final class Scopes {
      * @return A new Scopes object
      */
     public static Scopes of(ContainerRef containerRef, Scope... scopes) {
-        return new Scopes(containerRef, null, scopes);
+        return withRepositoryScopes(containerRef, null, null, scopes);
     }
 
     /**
@@ -88,7 +100,7 @@ public final class Scopes {
      * @return A new Scopes object
      */
     public static Scopes of(String service, ContainerRef containerRef, Scope... scopes) {
-        return new Scopes(containerRef, service, scopes);
+        return withRepositoryScopes(containerRef, service, null, scopes);
     }
 
     /**
@@ -98,7 +110,7 @@ public final class Scopes {
      * @return A new Scopes object with no scopes
      */
     public static Scopes empty(ContainerRef containerRef, String service) {
-        return new Scopes(containerRef, service, List.of());
+        return new Scopes(containerRef, service, null, List.of());
     }
 
     /**
@@ -107,7 +119,7 @@ public final class Scopes {
      * @return A new Scopes object with the given scopes
      */
     public Scopes withRegistryScopes(Scope... scopes) {
-        return new Scopes(containerRef, service, scopes);
+        return withRepositoryScopes(containerRef, service, identity, scopes);
     }
 
     /**
@@ -117,7 +129,10 @@ public final class Scopes {
      */
     public Scopes withAddedRegistryScopes(Scope... newScopes) {
         return new Scopes(
-                containerRef, service, ScopeUtils.appendRepositoryScope(this.scopes, containerRef, newScopes));
+                containerRef,
+                service,
+                identity,
+                ScopeUtils.appendRepositoryScope(this.scopes, containerRef, newScopes));
     }
 
     /**
@@ -129,7 +144,10 @@ public final class Scopes {
         List<String> newScopes = new LinkedList<>(scopes);
         newScopes.addAll(List.of(globalScopes));
         return new Scopes(
-                containerRef, service, newScopes.stream().sorted().distinct().toList());
+                containerRef,
+                service,
+                identity,
+                newScopes.stream().sorted().distinct().toList());
     }
 
     /**
@@ -142,7 +160,7 @@ public final class Scopes {
                 .sorted()
                 .distinct()
                 .toList();
-        return new Scopes(containerRef, service, globalScopes);
+        return new Scopes(containerRef, service, identity, globalScopes);
     }
 
     /**
@@ -155,7 +173,7 @@ public final class Scopes {
                 .sorted()
                 .distinct()
                 .toList();
-        return new Scopes(containerRef, service, nonGlobalScopes);
+        return new Scopes(containerRef, service, identity, nonGlobalScopes);
     }
 
     /**
@@ -166,7 +184,7 @@ public final class Scopes {
     public Scopes withNewScope(String scope) {
         List<String> newScopes = new LinkedList<>(scopes);
         newScopes.add(scope);
-        return new Scopes(containerRef, service, ScopeUtils.cleanScopes(newScopes));
+        return new Scopes(containerRef, service, identity, ScopeUtils.cleanScopes(newScopes));
     }
 
     /**
@@ -175,7 +193,16 @@ public final class Scopes {
      * @return A new Scopes object with the given service
      */
     public Scopes withService(@Nullable String service) {
-        return new Scopes(containerRef, service, scopes);
+        return new Scopes(containerRef, service, identity, scopes);
+    }
+
+    /**
+     * Return a new copy of the Scopes object bound to the given auth provider identity
+     * @param identity The identity
+     * @return The new Scopes object
+     */
+    public Scopes withIdentity(@Nullable String identity) {
+        return new Scopes(containerRef, service, identity, scopes);
     }
 
     /**
@@ -184,6 +211,14 @@ public final class Scopes {
      */
     public @Nullable String getService() {
         return service;
+    }
+
+    /**
+     * Get the auth provider identity marker bound to this scope, or {@code null} if not bound to any.
+     * @return The identity marker
+     */
+    public @Nullable String getIdentity() {
+        return identity;
     }
 
     /**
@@ -241,6 +276,7 @@ public final class Scopes {
         Scopes scopes1 = (Scopes) o;
         return Objects.equals(getScopes(), scopes1.getScopes())
                 && Objects.equals(getService(), scopes1.getService())
+                && Objects.equals(getIdentity(), scopes1.getIdentity())
                 && Objects.equals(
                         getContainerRef().getRegistry(),
                         scopes1.getContainerRef().getRegistry());
@@ -248,14 +284,16 @@ public final class Scopes {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getScopes(), getService(), getContainerRef().getRegistry());
+        return Objects.hash(
+                getScopes(), getService(), getIdentity(), getContainerRef().getRegistry());
     }
 
     @Override
     public String toString() {
         return "Scopes{" + "scopes="
                 + scopes + ", service='"
-                + service + '\'' + ", registry="
+                + service + '\'' + ", identity='"
+                + identity + '\'' + ", registry="
                 + containerRef.getRegistry() + '}';
     }
 }

--- a/src/test/java/land/oras/auth/AuthStoreAuthenticationProviderTest.java
+++ b/src/test/java/land/oras/auth/AuthStoreAuthenticationProviderTest.java
@@ -85,4 +85,28 @@ class AuthStoreAuthenticationProviderTest {
     void testDefaultLocation() {
         new AuthStoreAuthenticationProvider();
     }
+
+    @Test
+    void identityShouldFollowTheResolvedCredentialPerRegistry() {
+        ContainerRef alpine = ContainerRef.parse("%s/%s".formatted(REGISTRY, "alpine"));
+        ContainerRef busybox = ContainerRef.parse("%s/%s".formatted(REGISTRY, "busybox"));
+
+        doReturn(new Credential("alice", "alice-pass")).when(mockAuthStore).get(alpine);
+        doReturn(new Credential("bob", "bob-pass")).when(mockAuthStore).get(busybox);
+
+        AuthStoreAuthenticationProvider authProvider = new AuthStoreAuthenticationProvider(mockAuthStore);
+
+        assertEquals("BASIC:alice", authProvider.getIdentity(alpine));
+        assertEquals("BASIC:bob", authProvider.getIdentity(busybox));
+    }
+
+    @Test
+    void identityShouldFallBackToAnonymousWhenNoCredentialIsStored() {
+        doReturn(null).when(mockAuthStore).get(any(ContainerRef.class));
+
+        AuthStoreAuthenticationProvider authProvider = new AuthStoreAuthenticationProvider(mockAuthStore);
+
+        assertEquals(
+                "BASIC:anonymous", authProvider.getIdentity(ContainerRef.parse("%s/%s".formatted(REGISTRY, "alpine"))));
+    }
 }

--- a/src/test/java/land/oras/auth/BearerTokenProviderTest.java
+++ b/src/test/java/land/oras/auth/BearerTokenProviderTest.java
@@ -20,6 +20,9 @@
 
 package land.oras.auth;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import land.oras.ContainerRef;
@@ -38,5 +41,28 @@ class BearerTokenProviderTest {
     void shouldHaveNoAuthHeader() {
         BearerTokenProvider provider = new BearerTokenProvider();
         assertNull(provider.getAuthHeader(containerRef), "No token should be returned");
+    }
+
+    @Test
+    void identityShouldDependOnTheTokenValueAndNeverLeakIt() {
+        BearerTokenProvider noToken = new BearerTokenProvider();
+        assertEquals("BEARER:none", noToken.getIdentity(containerRef));
+
+        BearerTokenProvider tokenA = new BearerTokenProvider("secret-token-a");
+        BearerTokenProvider sameTokenA = new BearerTokenProvider("secret-token-a");
+        BearerTokenProvider tokenB = new BearerTokenProvider("secret-token-b");
+
+        assertNotEquals(noToken.getIdentity(containerRef), tokenA.getIdentity(containerRef));
+        assertEquals(
+                tokenA.getIdentity(containerRef),
+                sameTokenA.getIdentity(containerRef),
+                "Same token value should yield the same identity");
+        assertNotEquals(
+                tokenA.getIdentity(containerRef),
+                tokenB.getIdentity(containerRef),
+                "Different token values are different identities");
+        assertFalse(
+                tokenA.getIdentity(containerRef).contains("secret-token-a"),
+                "Identity must never contain the raw token");
     }
 }

--- a/src/test/java/land/oras/auth/NoAuthProviderTest.java
+++ b/src/test/java/land/oras/auth/NoAuthProviderTest.java
@@ -20,6 +20,7 @@
 
 package land.oras.auth;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import land.oras.ContainerRef;
@@ -34,5 +35,16 @@ class NoAuthProviderTest {
     void shouldHaveNoAuthHeader() {
         NoAuthProvider authProvider = new NoAuthProvider();
         assertNull(authProvider.getAuthHeader(ContainerRef.parse("localhost:5000/foo/bar")));
+    }
+
+    @Test
+    void shouldHaveDistinctIdentityFromCredentialedProviders() {
+        NoAuthProvider authProvider = new NoAuthProvider();
+        ContainerRef registry = ContainerRef.parse("localhost:5000/foo/bar");
+        assertEquals(AuthScheme.NONE.name(), authProvider.getIdentity(registry));
+        assertEquals(
+                authProvider.getIdentity(registry),
+                authProvider.getIdentity(ContainerRef.parse("localhost:5000/other/repo")),
+                "Anonymous identity should not depend on the target repository");
     }
 }

--- a/src/test/java/land/oras/auth/ScopesTest.java
+++ b/src/test/java/land/oras/auth/ScopesTest.java
@@ -42,11 +42,12 @@ class ScopesTest {
         assertSame(containerRef, scopes.getContainerRef());
         assertEquals("localhost:5000", scopes.getRegistry());
         assertEquals("docker", scopes.withService("docker").getService());
+        assertNull(scopes.getIdentity(), "Identity should be null by default");
         assertEquals(
-                "Scopes{scopes=[repository:library/test:pull], service='null', registry=localhost:5000}",
+                "Scopes{scopes=[repository:library/test:pull], service='null', identity='null', registry=localhost:5000}",
                 scopes.toString());
         assertEquals(
-                "Scopes{scopes=[repository:library/test:pull], service='docker', registry=localhost:5000}",
+                "Scopes{scopes=[repository:library/test:pull], service='docker', identity='null', registry=localhost:5000}",
                 scopes.withService("docker").toString());
         assertFalse(scopes.isGlobal(), "Scopes should not be global");
         assertTrue(
@@ -67,5 +68,44 @@ class ScopesTest {
         assertNotSame(newScopes, newScopes2, "Scopes should be immutable");
         assertEquals(1, newScopes2.getScopes().size());
         assertEquals("repository:library/test:pull,push", newScopes2.getScopes().get(0));
+    }
+
+    @Test
+    void shouldCarryIdentityThroughAllWithers() {
+        ContainerRef containerRef = ContainerRef.parse("localhost:5000/library/test:latest");
+        Scopes scopes = Scopes.of(containerRef, Scope.PULL).withIdentity("BASIC:alice");
+        assertEquals("BASIC:alice", scopes.getIdentity());
+
+        // Every wither must preserve the identity bound on the original instance
+        assertEquals("BASIC:alice", scopes.withService("docker").getIdentity());
+        assertEquals("BASIC:alice", scopes.withRegistryScopes(Scope.PUSH).getIdentity());
+        assertEquals("BASIC:alice", scopes.withAddedRegistryScopes(Scope.PUSH).getIdentity());
+        assertEquals("BASIC:alice", scopes.withAddedGlobalScopes("aws").getIdentity());
+        assertEquals(
+                "BASIC:alice",
+                scopes.withAddedGlobalScopes("aws").withOnlyGlobalScopes().getIdentity());
+        assertEquals(
+                "BASIC:alice",
+                scopes.withAddedGlobalScopes("aws").withoutGlobalScopes().getIdentity());
+        assertEquals("BASIC:alice", scopes.withNewScope("aws").getIdentity());
+
+        // Overriding the identity replaces it, everything else stays the same
+        Scopes rebound = scopes.withIdentity("BASIC:bob");
+        assertEquals("BASIC:bob", rebound.getIdentity());
+        assertEquals(scopes.getScopes(), rebound.getScopes());
+    }
+
+    @Test
+    void scopesWithDifferentIdentityShouldNotBeEqual() {
+        ContainerRef containerRef = ContainerRef.parse("localhost:5000/library/test:latest");
+        Scopes anonymous = Scopes.of(containerRef, Scope.PULL).withIdentity("NONE");
+        Scopes alice = Scopes.of(containerRef, Scope.PULL).withIdentity("BASIC:alice");
+        Scopes bob = Scopes.of(containerRef, Scope.PULL).withIdentity("BASIC:bob");
+        Scopes aliceAgain = Scopes.of(containerRef, Scope.PULL).withIdentity("BASIC:alice");
+
+        assertNotEquals(anonymous, alice, "Anonymous and a credentialed identity must not collide");
+        assertNotEquals(alice, bob, "Two distinct credentialed identities must not collide");
+        assertEquals(alice, aliceAgain, "Same identity for the same scope should still be equal");
+        assertEquals(alice.hashCode(), aliceAgain.hashCode(), "Equal scopes must have equal hash codes");
     }
 }

--- a/src/test/java/land/oras/auth/TokenCacheTest.java
+++ b/src/test/java/land/oras/auth/TokenCacheTest.java
@@ -22,6 +22,7 @@ package land.oras.auth;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.micrometer.core.instrument.FunctionCounter;
@@ -121,5 +122,35 @@ class TokenCacheTest {
         TokenCache.put(scopes, tokenResponse);
         Scopes pullOnlyScopes = Scopes.of(containerRef, Scope.PULL); // Pull only
         assertEquals(tokenResponse, TokenCache.get(pullOnlyScopes), "Should retrieve the token using pull-only scopes");
+    }
+
+    /**
+     * Regression test for a token cache poisoning scenario: a first, anonymous, request for a given
+     * registry/repository/action scope is answered with an (anonymously-scoped) token, which gets cached. A later
+     * request for the exact same scope, but resolved with real credentials, must NOT be served that stale anonymous
+     * token from the cache — it must be treated as a cache miss so the caller falls back to its own AuthProvider.
+     */
+    @Test
+    void shouldNotServeATokenCachedForOneIdentityToADifferentIdentity() {
+        ContainerRef containerRef = ContainerRef.parse("docker.io/library/jenkins-common-configuration:main");
+        HttpClient.TokenResponse anonymousToken =
+                new HttpClient.TokenResponse("anonymous-token", null, "prj-sso-oci", 3600, null);
+
+        Scopes anonymousScope =
+                Scopes.of(containerRef, Scope.PULL).withService("prj-sso-oci").withIdentity("NONE");
+        TokenCache.put(anonymousScope, anonymousToken);
+
+        // Same registry, same repository, same pull action, but a different (credentialed) identity
+        Scopes credentialedScope =
+                Scopes.of(containerRef, Scope.PULL).withService("prj-sso-oci").withIdentity("BASIC:sa_elca-samples");
+
+        assertEquals(
+                anonymousToken,
+                TokenCache.get(anonymousScope),
+                "The anonymous identity should still get its own cached token");
+        assertNull(
+                TokenCache.get(credentialedScope),
+                "A different identity must never be served a token cached for another identity, "
+                        + "even for the exact same registry/repository/action scope");
     }
 }

--- a/src/test/java/land/oras/auth/UsernamePasswordProviderTest.java
+++ b/src/test/java/land/oras/auth/UsernamePasswordProviderTest.java
@@ -21,6 +21,8 @@
 package land.oras.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import land.oras.ContainerRef;
 import org.junit.jupiter.api.Test;
@@ -47,5 +49,23 @@ class UsernamePasswordProviderTest {
         // Getters
         assertEquals("user", authProvider.getUsername(), "Username should be correct");
         assertEquals("pass", authProvider.getPassword(), "Password should be correct");
+    }
+
+    @Test
+    void identityShouldDependOnUsernameOnlyAndNeverLeakThePassword() {
+        ContainerRef registry = ContainerRef.parse("localhost:5000/foo");
+        AbstractUsernamePasswordProvider user = new UsernamePasswordProvider("user", "pass");
+        AbstractUsernamePasswordProvider sameUserOtherPassword = new UsernamePasswordProvider("user", "other-pass");
+        AbstractUsernamePasswordProvider otherUser = new UsernamePasswordProvider("other-user", "pass");
+
+        assertEquals(
+                user.getIdentity(registry),
+                sameUserOtherPassword.getIdentity(registry),
+                "Identity should not depend on the password");
+        assertNotEquals(
+                user.getIdentity(registry),
+                otherUser.getIdentity(registry),
+                "Different usernames are different identities");
+        assertFalse(user.getIdentity(registry).contains("pass"), "Identity must never contain the raw password");
     }
 }


### PR DESCRIPTION
### Description

Key `TokenCache` entries by auth provider identity, not just scope

### Testing done

Let CI do it

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
