### PR TITLE
Use FQDN for shouldPullOneBlob on GitHub action due to multiple unqualified reference

### DIFF
--- a/src/test/java/land/oras/DockerIoITCase.java
+++ b/src/test/java/land/oras/DockerIoITCase.java
@@ -90,7 +90,7 @@ class DockerIoITCase {
     @Test
     void shouldPullOneBlob() {
         Registry registry = Registry.builder().build();
-        ContainerRef containerRef1 = ContainerRef.parse("jbangdev/jbang-action");
+        ContainerRef containerRef1 = ContainerRef.parse("docker.io/jbangdev/jbang-action");
         String effectiveRegistry = containerRef1.getEffectiveRegistry(registry);
         Manifest manifest = registry.getManifest(containerRef1);
         Layer oneLayer = manifest.getLayers().get(0);


### PR DESCRIPTION
### Description

Use FQDN for shouldPullOneBlob on GitHub action due to multiple unqualified reference

### Testing done

mvn clean install

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
