### PR TITLE
Do not send a cached token during token refresh

### DIFF
--- a/src/main/java/land/oras/auth/HttpClient.java
+++ b/src/main/java/land/oras/auth/HttpClient.java
@@ -297,11 +297,13 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.noBody(),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
     private ResponseWrapper<String> getForTokenRefresh(
             URI uri, Map<String, String> headers, Scopes scopes, AuthProvider authProvider) {
+        // No retry or cached token
         return executeRequest(
                 "GET",
                 uri,
@@ -312,6 +314,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.noBody(),
                 scopes,
                 authProvider,
+                false,
                 false);
     }
 
@@ -336,6 +339,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.noBody(),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -359,6 +363,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.noBody(),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -385,6 +390,7 @@ public final class HttpClient {
                     HttpRequest.BodyPublishers.ofFile(file),
                     scopes,
                     authProvider,
+                    true,
                     true);
         } catch (FileNotFoundException e) {
             throw new OrasException("Unable to upload file. File not found.", e);
@@ -418,6 +424,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.fromPublisher(HttpRequest.BodyPublishers.ofInputStream(stream), size),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -441,6 +448,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.noBody(),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -464,6 +472,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.noBody(),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -488,6 +497,7 @@ public final class HttpClient {
                 body.length == 0 ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofByteArray(body),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -512,6 +522,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.ofByteArray(body),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -542,6 +553,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.fromPublisher(HttpRequest.BodyPublishers.ofInputStream(stream), chunkSize),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -566,6 +578,7 @@ public final class HttpClient {
                 HttpRequest.BodyPublishers.ofByteArray(body),
                 scopes,
                 authProvider,
+                true,
                 true);
     }
 
@@ -631,6 +644,13 @@ public final class HttpClient {
                                         ? "<redacted" // Replace value with ****
                                         : entry.getValue())));
 
+        if (responseWrapper.response().isBlank()) {
+            throw new OrasException(
+                    responseWrapper.statusCode(),
+                    "Token endpoint returned no JSON body (status=%d, realm=%s, service=%s)"
+                            .formatted(responseWrapper.statusCode(), realm, service));
+        }
+
         // Put in the cache
         TokenResponse token = JsonUtils.fromJson(responseWrapper.response(), TokenResponse.class)
                 .forService(service);
@@ -670,6 +690,7 @@ public final class HttpClient {
      * @param scopes The scopes
      * @param authProvider The authentication provider
      * @param retryEnabled Whether transient failures should be retried
+     * @param allowCachedToken Whether a bearer cached for this scope may be attached
      * @return The response
      */
     private <T> ResponseWrapper<T> executeRequest(
@@ -682,7 +703,8 @@ public final class HttpClient {
             HttpRequest.BodyPublisher bodyPublisher,
             Scopes scopes,
             AuthProvider authProvider,
-            boolean retryEnabled) {
+            boolean retryEnabled,
+            boolean allowCachedToken) {
 
         // Scopes are invariant across retries — compute once.
         ContainerRef containerRef = scopes.getContainerRef();
@@ -706,7 +728,9 @@ public final class HttpClient {
                 HttpRequest.Builder builder = HttpRequest.newBuilder().uri(uri).method(method, bodyPublisher);
 
                 // Check token cache — may be populated by a prior attempt's 401 handling.
-                TokenResponse cachedToken = TokenCache.get(newScopes);
+                // Disabled for token-refresh requests (allowCachedToken=false): the token endpoint
+                // must always see the configured AuthProvider credentials, never a resource-server bearer.
+                TokenResponse cachedToken = allowCachedToken ? TokenCache.get(newScopes) : null;
                 if (cachedToken == null) {
                     LOG.trace("No token found in cache for scopes: {}", newScopes);
                 } else {
@@ -751,7 +775,8 @@ public final class HttpClient {
                             bodyPublisher,
                             newScopes,
                             authProvider,
-                            retryEnabled);
+                            retryEnabled,
+                            allowCachedToken);
                 }
 
                 // Retry on 429 / 5xx before delegating 401/403 to redoRequest.

--- a/src/test/java/land/oras/RegistryWireMockTest.java
+++ b/src/test/java/land/oras/RegistryWireMockTest.java
@@ -22,6 +22,7 @@ package land.oras;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -732,6 +733,102 @@ class RegistryWireMockTest {
                         .sum());
         TestUtils.dumpMetrics(meterRegistry);
         TestUtils.dumpMetrics(Metrics.globalRegistry);
+    }
+
+    @Test
+    void shouldNotLeakCachedPushTokenToTokenEndpointOnPutRefresh(WireMockRuntimeInfo wmRuntimeInfo) {
+        // Regression test for https://github.com/oras-project/oras-java/issues/846
+        // Ensure we don't send a cached token during token refresh
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        String registryUrl = wmRuntimeInfo.getHttpBaseUrl().replace("http://", "");
+        String repo = "token-leak";
+        byte[] data = "token-leak-payload".getBytes(StandardCharsets.UTF_8);
+        String tokenPath = "/token?scope=repository:library/%s:pull,push&service=localhost".formatted(repo);
+        String wwwAuthenticate =
+                "Bearer realm=\"http://%s/token\",service=\"localhost\",scope=\"repository:library/%s:pull,push\""
+                        .formatted(registryUrl, repo);
+
+        // Blob does not exist yet
+        wireMock.register(WireMock.head(WireMock.urlPathMatching("/v2/library/%s/blobs/.*".formatted(repo)))
+                .willReturn(WireMock.status(404)));
+
+        // POST upload init: the API endpoint only accepts the issued bearer, never Basic
+        wireMock.register(WireMock.post(WireMock.urlPathMatching("/v2/library/%s/blobs/uploads/.*".formatted(repo)))
+                .atPriority(1)
+                .withHeader(Const.AUTHORIZATION_HEADER, WireMock.equalTo("Bearer post-token"))
+                .willReturn(WireMock.aResponse().withStatus(202).withHeader(Const.LOCATION_HEADER, "/upload")));
+        wireMock.register(WireMock.post(WireMock.urlPathMatching("/v2/library/%s/blobs/uploads/.*".formatted(repo)))
+                .atPriority(2)
+                .willReturn(WireMock.unauthorized().withHeader(Const.WWW_AUTHENTICATE_HEADER, wwwAuthenticate)));
+
+        // PUT completing the upload: same deal - only the correctly-scoped bearer is accepted
+        wireMock.register(WireMock.put(WireMock.urlPathMatching("/upload.*"))
+                .atPriority(1)
+                .withHeader(Const.AUTHORIZATION_HEADER, WireMock.equalTo("Bearer post-token"))
+                .willReturn(WireMock.created()));
+        wireMock.register(WireMock.put(WireMock.urlPathMatching("/upload.*"))
+                .atPriority(2)
+                .willReturn(WireMock.unauthorized().withHeader(Const.WWW_AUTHENTICATE_HEADER, wwwAuthenticate)));
+
+        // Token endpoint: issues a token for the Basic credential, but returns 200 with an empty bodyqmvn
+        wireMock.register(WireMock.get(WireMock.urlEqualTo(tokenPath))
+                .withHeader(Const.AUTHORIZATION_HEADER, WireMock.containing("Basic"))
+                .willReturn(WireMock.okJson(JsonUtils.toJson(
+                        new HttpClient.TokenResponse("post-token", null, "localhost", 300, ZonedDateTime.now())))));
+        wireMock.register(WireMock.get(WireMock.urlEqualTo(tokenPath))
+                .withHeader(Const.AUTHORIZATION_HEADER, WireMock.containing("Bearer"))
+                .willReturn(WireMock.ok()));
+
+        Registry registry = Registry.Builder.builder()
+                .withAuthProvider(authProvider)
+                .withInsecure(true)
+                .build();
+        ContainerRef containerRef = ContainerRef.parse("%s/library/%s".formatted(registryUrl, repo));
+
+        assertDoesNotThrow(
+                () -> registry.pushBlob(containerRef, data),
+                "Completing the upload must use the configured credentials, not a cached bearer, "
+                        + "when refreshing the token (see issue #846)");
+
+        // The token endpoint must never be presented the cached registry bearer as its own credential
+        wireMock.verifyThat(
+                0,
+                WireMock.getRequestedFor(WireMock.urlEqualTo(tokenPath))
+                        .withHeader(Const.AUTHORIZATION_HEADER, WireMock.containing("Bearer")));
+    }
+
+    @Test
+    void shouldFailWithClearErrorWhenTokenEndpointReturnsBlankBody(WireMockRuntimeInfo wmRuntimeInfo) {
+        // A token endpoint that returns a blank body
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        String repo = "blank-token-body";
+        String digest = SupportedAlgorithm.SHA256.digest("blob-data".getBytes());
+        String realm = "http://localhost:%d/token".formatted(wmRuntimeInfo.getHttpPort());
+
+        wireMock.register(WireMock.any(WireMock.urlEqualTo("/v2/library/%s/blobs/%s".formatted(repo, digest)))
+                .willReturn(WireMock.unauthorized()
+                        .withHeader(
+                                Const.WWW_AUTHENTICATE_HEADER,
+                                "Bearer realm=\"%s\",service=\"localhost\",scope=\"repository:library/%s:pull\""
+                                        .formatted(realm, repo))));
+
+        wireMock.register(WireMock.get(WireMock.urlEqualTo(
+                        "/token?scope=repository:library/%s:pull&service=localhost".formatted(repo)))
+                .willReturn(WireMock.aResponse().withStatus(200).withBody(" ")));
+
+        Registry registry = Registry.Builder.builder()
+                .withAuthProvider(authProvider)
+                .withInsecure(true)
+                .build();
+        ContainerRef containerRef =
+                ContainerRef.parse("localhost:%d/library/%s".formatted(wmRuntimeInfo.getHttpPort(), repo));
+
+        OrasException thrown =
+                assertThrows(OrasException.class, () -> registry.getBlob(containerRef.withDigest(digest)));
+        assertTrue(thrown.getMessage().contains("Token endpoint returned no JSON body"));
+        assertTrue(thrown.getMessage().contains("status=200"));
+        assertTrue(thrown.getMessage().contains(realm));
+        assertTrue(thrown.getMessage().contains("service=localhost"));
     }
 
     @Test


### PR DESCRIPTION
### Description

Should fix https://github.com/oras-project/oras-java/issues/846

See issue for detailed description

### Testing done

CI and one regression test

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
