### PR TITLE
Shorten FQDN types and enforce it with spotless 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
     <awaitability.version>4.3.0</awaitability.version>
 
     <!-- Plugin version -->
-    <palantir.java.format.version>2.74.0</palantir.java.format.version>
     <build.helper-maven-plugin.version>3.6.1</build.helper-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <spotless-maven-plugin.version>3.10.0</spotless-maven-plugin.version>
@@ -601,15 +600,14 @@
           <version>${spotless-maven-plugin.version}</version>
           <configuration>
             <java>
+              <toggleOffOn />
               <endWithNewline />
+              <shortenFullyQualifiedTypes />
               <importOrder />
               <indent>
                 <spaces>true</spaces>
               </indent>
-              <palantirJavaFormat>
-                <!-- Until http://github.com/diffplug/spotless/issues/2468 -->
-                <version>${palantir.java.format.version}</version>
-              </palantirJavaFormat>
+              <palantirJavaFormat />
               <removeUnusedImports />
               <trimTrailingWhitespace />
             </java>

--- a/src/main/java/land/oras/Registry.java
+++ b/src/main/java/land/oras/Registry.java
@@ -22,6 +22,7 @@ package land.oras;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1176,7 +1177,7 @@ public final class Registry extends OCI<ContainerRef> {
                                 Const.APPLICATION_OCTET_STREAM_HEADER_VALUE,
                                 Const.CONTENT_RANGE_HEADER,
                                 contentRange),
-                        () -> new java.io.ByteArrayInputStream(chunk),
+                        () -> new ByteArrayInputStream(chunk),
                         Scopes.of(ref),
                         authProvider);
                 logResponse(patchResponse);

--- a/src/main/java/land/oras/Tags.java
+++ b/src/main/java/land/oras/Tags.java
@@ -35,7 +35,11 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 @OrasModel
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record Tags(String name, List<String> tags, @Nullable String last, @Nullable Integer n) {
+public record Tags(
+        String name,
+        List<String> tags,
+        @Nullable String last,
+        @Nullable Integer n) {
 
     /**
      * Constructor without last

--- a/src/main/java/land/oras/auth/HttpClient.java
+++ b/src/main/java/land/oras/auth/HttpClient.java
@@ -20,14 +20,22 @@
 
 package land.oras.auth;
 
+// spotless:off
+// Until https://github.com/diffplug/spotless/issues/3033
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
-import java.net.*;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.HttpURLConnection;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
@@ -66,6 +74,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+// spotless:on
 
 /**
  * HTTP client for ORAS
@@ -87,12 +96,15 @@ public final class HttpClient {
     /**
      * The HTTP client builder
      */
+    // spotless:off
+    // Until https://github.com/diffplug/spotless/issues/3033
     private final java.net.http.HttpClient.Builder builder;
 
     /**
      * The HTTP client
      */
     private java.net.http.HttpClient client;
+    // spotless:on
 
     /**
      * Skip TLS verification
@@ -834,7 +846,7 @@ public final class HttpClient {
     }
 
     private static boolean isRetryableException(Exception e) {
-        return e instanceof HttpTimeoutException || e instanceof java.io.IOException;
+        return e instanceof HttpTimeoutException || e instanceof IOException;
     }
 
     private long computeRetryDelay(@Nullable HttpResponse<?> response, int attempt) {
@@ -989,7 +1001,10 @@ public final class HttpClient {
      * @param service The service (not on response but on HTTP headers)
      */
     public record ResponseWrapper<T>(
-            T response, int statusCode, Map<String, String> headers, @Nullable String service) {}
+            T response,
+            int statusCode,
+            Map<String, String> headers,
+            @Nullable String service) {}
 
     /**
      * Insecure trust manager when skipping TLS verification

--- a/src/main/java/land/oras/auth/RegistriesConf.java
+++ b/src/main/java/land/oras/auth/RegistriesConf.java
@@ -329,7 +329,9 @@ public class RegistriesConf {
             @JsonProperty("short-name-mode") @Nullable ShortNameMode shortNameMode,
             @JsonProperty("registry") @Nullable List<RegistryConfig> registries,
             @JsonProperty("aliases") @Nullable Map<String, String> aliases,
-            @JsonProperty("unqualified-search-registries") @Nullable List<String> unqualifiedRegistries) {}
+
+            @JsonProperty("unqualified-search-registries") @Nullable
+            List<String> unqualifiedRegistries) {}
 
     /**
      * Get the list of unqualified registries.

--- a/src/main/java/land/oras/policy/SigstoreVerifier.java
+++ b/src/main/java/land/oras/policy/SigstoreVerifier.java
@@ -30,6 +30,7 @@ import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -287,7 +288,7 @@ final class SigstoreVerifier {
      * @return a non-null (possibly empty) list of successfully loaded public keys.
      */
     static List<PublicKey> loadKeys(PolicyRequirement.SigstoreSigned requirement) {
-        java.util.List<PublicKey> keys = new java.util.ArrayList<>();
+        List<PublicKey> keys = new ArrayList<>();
 
         // Single-key fields
         PublicKey single = loadKey(requirement);
@@ -391,7 +392,8 @@ final class SigstoreVerifier {
      * @param subject The subject
      */
     @OrasModel
-    record InTotoStatement(@JsonProperty("subject") @Nullable List<Subject> subject) {}
+    record InTotoStatement(
+            @JsonProperty("subject") @Nullable List<Subject> subject) {}
 
     /**
      * An in-toto subject: a map of digest algorithm to hex value

--- a/src/test/java/land/oras/ContainerRefTest.java
+++ b/src/test/java/land/oras/ContainerRefTest.java
@@ -40,8 +40,7 @@ class ContainerRefTest {
     @Execution(ExecutionMode.SAME_THREAD)
     void shouldReadRegistriesConfig(@TempDir Path homeDir) throws Exception {
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "public.ecr.aws"
             blocked = true
@@ -82,8 +81,7 @@ class ContainerRefTest {
     void shouldDetermineFromAlias(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
             [aliases]
             "my-library/my-namespace"="localhost:5000/test"
             "my-library"="localhost:5000/test2"
@@ -105,8 +103,7 @@ class ContainerRefTest {
     void shouldRewriteAllSubdomainToLocalProxy(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
                 [[registry]]
                 prefix = "*.example.com"
                 location = "localhost:5000/example-com"

--- a/src/test/java/land/oras/DockerIoITCase.java
+++ b/src/test/java/land/oras/DockerIoITCase.java
@@ -149,8 +149,7 @@ class DockerIoITCase {
     void shouldCopyTagToInternalRegistryViaAlias(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
             [aliases]
             "dockerhub-alpine" = "docker.io/library/alpine"
             """;

--- a/src/test/java/land/oras/GitHubContainerRegistryITCase.java
+++ b/src/test/java/land/oras/GitHubContainerRegistryITCase.java
@@ -85,17 +85,14 @@ class GitHubContainerRegistryITCase {
         Path publicKeyPath = Path.of("src/test/resources/keys/sigstore/alpine-signed.pub");
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "ghcr.io"
             insecure = false
             """;
 
         // language=json
-        Files.writeString(
-                path,
-                """
+        Files.writeString(path, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -104,8 +101,7 @@ class GitHubContainerRegistryITCase {
                     }
                   }
                 }
-                """
-                        .formatted(publicKeyPath.toAbsolutePath().toString()));
+                """.formatted(publicKeyPath.toAbsolutePath().toString()));
         ContainersPolicy policy = ContainersPolicy.newPolicy(path);
         TestUtils.createRegistriesConfFile(homeDir, config);
         TestUtils.withHome(homeDir, () -> {
@@ -120,8 +116,7 @@ class GitHubContainerRegistryITCase {
     @Execution(ExecutionMode.SAME_THREAD)
     void shouldPullIndexWithAlias(@TempDir Path homeDir) throws Exception {
         // language=toml
-        String config =
-                """
+        String config = """
                 [aliases]
                 "oras"="ghcr.io/oras-project/oras"
                 """;

--- a/src/test/java/land/oras/HarborS3ITCase.java
+++ b/src/test/java/land/oras/HarborS3ITCase.java
@@ -178,8 +178,7 @@ class HarborS3ITCase {
     void shouldPushJenkinsScriptArtifact() {
 
         // language=groovy
-        String jenkinsfile =
-                """
+        String jenkinsfile = """
                     node {
                         stage('Build') {
                             echo 'Building...'

--- a/src/test/java/land/oras/LayerTest.java
+++ b/src/test/java/land/oras/LayerTest.java
@@ -77,8 +77,7 @@ class LayerTest {
 
     @Test
     void shouldReadNullAnnotations() {
-        String json =
-                """
+        String json = """
             {
               "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
               "digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -94,8 +93,7 @@ class LayerTest {
 
     @Test
     void shouldReadBlobData() {
-        String json =
-                """
+        String json = """
             {
               "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
               "digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -155,14 +153,12 @@ class LayerTest {
      * @return The manifest
      */
     private String sampleLayer() {
-        return Layer.fromJson(
-                        """
+        return Layer.fromJson("""
                             {
                               "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
                               "digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
                               "size": 32654
                             }
-                        """)
-                .toJson();
+                        """).toJson();
     }
 }

--- a/src/test/java/land/oras/OCILayoutTest.java
+++ b/src/test/java/land/oras/OCILayoutTest.java
@@ -166,9 +166,7 @@ class OCILayoutTest {
         Path policyPath = homeDir.resolve("policy.json");
 
         // language=json
-        Files.writeString(
-                policyPath,
-                """
+        Files.writeString(policyPath, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -177,8 +175,7 @@ class OCILayoutTest {
                     }
                   }
                 }
-                """
-                        .formatted(registry.getRegistry(), publicKeyPath.toAbsolutePath()));
+                """.formatted(registry.getRegistry(), publicKeyPath.toAbsolutePath()));
         ContainersPolicy policy = ContainersPolicy.newPolicy(policyPath);
 
         // Pull the manifest with the policy: the attached signature is fetched and verified.

--- a/src/test/java/land/oras/PlatformTest.java
+++ b/src/test/java/land/oras/PlatformTest.java
@@ -112,8 +112,7 @@ class PlatformTest {
     @Test
     void shouldReadFromJson() {
         // language=json
-        String json =
-                """
+        String json = """
             {
               "architecture": "amd64",
               "os": "linux"
@@ -125,8 +124,7 @@ class PlatformTest {
         assertNull(platform.variant());
         assertEquals(Platform.linuxAmd64(), platform);
 
-        json =
-                """
+        json = """
             {
               "architecture": "unknown",
               "os": "unknown"
@@ -139,8 +137,7 @@ class PlatformTest {
     @Test
     void shouldReadFromJsonWithOptionalValues() {
         // language=json
-        String json =
-                """
+        String json = """
             {
               "architecture": "amd64",
               "variant": "v8",
@@ -164,8 +161,7 @@ class PlatformTest {
                         .withVariant("v8"),
                 platform);
 
-        json =
-                """
+        json = """
             {
               "architecture": "unknown",
               "os": "unknown"

--- a/src/test/java/land/oras/PublicECRITCase.java
+++ b/src/test/java/land/oras/PublicECRITCase.java
@@ -60,8 +60,7 @@ class PublicECRITCase {
     void shouldRewriteDockerIOToPublicECR() throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
                 [[registry]]
                 prefix = "docker.io/library"
                 location = "public.ecr.aws/docker/library"

--- a/src/test/java/land/oras/RegistryMirrorTest.java
+++ b/src/test/java/land/oras/RegistryMirrorTest.java
@@ -70,8 +70,7 @@ class RegistryMirrorTest {
         //   mirror 1: localhost:59999 (down, connection refused)
         //   mirror 2: the running mirrorUp container
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -83,8 +82,7 @@ class RegistryMirrorTest {
                 [[registry.mirror]]
                 location = "%s"
                 insecure = true
-                """
-                        .formatted(mirrorRegistry);
+                """.formatted(mirrorRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -107,8 +105,7 @@ class RegistryMirrorTest {
         setupRegistry.pushArtifact(mirrorArtifact, LocalPath.of(testFile));
 
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -120,8 +117,7 @@ class RegistryMirrorTest {
                 [[registry.mirror]]
                 location = "%s"
                 insecure = true
-                """
-                        .formatted(mirrorRegistry);
+                """.formatted(mirrorRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -147,8 +143,7 @@ class RegistryMirrorTest {
 
         // Mirror location includes a path prefix → covers mirrorLocation.contains("/") branch.
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -156,8 +151,7 @@ class RegistryMirrorTest {
                 [[registry.mirror]]
                 location = "%s/prefix"
                 insecure = true
-                """
-                        .formatted(mirrorRegistry);
+                """.formatted(mirrorRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -182,8 +176,7 @@ class RegistryMirrorTest {
         Layer layer = setupRegistry.pushBlob(mirrorRef, blobContent);
 
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -195,8 +188,7 @@ class RegistryMirrorTest {
                 [[registry.mirror]]
                 location = "%s"
                 insecure = true
-                """
-                        .formatted(mirrorRegistry);
+                """.formatted(mirrorRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -241,8 +233,7 @@ class RegistryMirrorTest {
 
         // Configure docker.io with a mirror — unqualified refs resolve to docker.io by default
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 short-name-mode = "disabled"
 
                 unqualified-search-registries = ["docker.io"]
@@ -254,8 +245,7 @@ class RegistryMirrorTest {
                 [[registry.mirror]]
                 location = "%s"
                 insecure = true
-                """
-                        .formatted(mirrorRegistry);
+                """.formatted(mirrorRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -286,8 +276,7 @@ class RegistryMirrorTest {
         // is actually configured as the search registry below. The mirror here is unreachable: resolution
         // must catch that failure and fall back to probing the search registry directly.
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 short-name-mode = "disabled"
 
                 unqualified-search-registries = ["%s"]
@@ -298,8 +287,7 @@ class RegistryMirrorTest {
                 [[registry.mirror]]
                 location = "localhost:59999"
                 insecure = true
-                """
-                        .formatted(searchRegistry);
+                """.formatted(searchRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -323,8 +311,7 @@ class RegistryMirrorTest {
         String searchRegistry = mirrorUp.getRegistry();
 
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 short-name-mode = "disabled"
 
                 unqualified-search-registries = ["%s"]
@@ -335,8 +322,7 @@ class RegistryMirrorTest {
                 [[registry.mirror]]
                 location = "localhost:59999"
                 insecure = true
-                """
-                        .formatted(searchRegistry);
+                """.formatted(searchRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -365,8 +351,7 @@ class RegistryMirrorTest {
 
         // Mirror configured as digest-only — a tag-based pull must NOT use it
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -375,8 +360,7 @@ class RegistryMirrorTest {
                 location = "%s"
                 insecure = true
                 pull-from-mirror = "digest-only"
-                """
-                        .formatted(mirrorRegistry);
+                """.formatted(mirrorRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -385,7 +369,7 @@ class RegistryMirrorTest {
             // Pull by tag: digest-only mirror is skipped; fallback to "original" (also down) → must fail
             ContainerRef ref = ContainerRef.parse("localhost:59998/test/digest-only-mirror:v1");
             assertThrows(
-                    land.oras.exception.OrasException.class,
+                    OrasException.class,
                     () -> registry.getManifest(ref),
                     "digest-only mirror must be skipped for a tag-based pull");
         });
@@ -407,8 +391,7 @@ class RegistryMirrorTest {
         String digest = pushed.getDescriptor().getDigest();
 
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -417,8 +400,7 @@ class RegistryMirrorTest {
                 location = "%s"
                 insecure = true
                 pull-from-mirror = "digest-only"
-                """
-                        .formatted(mirrorRegistry);
+                """.formatted(mirrorRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -447,8 +429,7 @@ class RegistryMirrorTest {
         String digest = pushed.getDescriptor().getDigest();
 
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -457,8 +438,7 @@ class RegistryMirrorTest {
                 [[registry.mirror]]
                 location = "%s"
                 insecure = true
-                """
-                        .formatted(mirrorRegistry);
+                """.formatted(mirrorRegistry);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -468,7 +448,7 @@ class RegistryMirrorTest {
             // Tag pull, mirror-by-digest-only skips all mirrors. Fail with original down
             ContainerRef tagRef = ContainerRef.parse("localhost:59998/test/mbd-mirror:v1");
             assertThrows(
-                    land.oras.exception.OrasException.class,
+                    OrasException.class,
                     () -> registry.getManifest(tagRef),
                     "mirror-by-digest-only must skip mirrors for tag-based pulls");
 

--- a/src/test/java/land/oras/RegistryTest.java
+++ b/src/test/java/land/oras/RegistryTest.java
@@ -85,8 +85,7 @@ class RegistryTest {
         // language=toml
         String config = """
                 unqualified-search-registries = ["%s"]
-                """
-                .formatted(registry.getRegistry());
+                """.formatted(registry.getRegistry());
 
         TestUtils.createRegistriesConfFile(homeDir, config);
 
@@ -105,8 +104,7 @@ class RegistryTest {
         // language=toml
         String config = """
                 unqualified-search-registries = ["%s", "localhost:5000"]
-                """
-                .formatted(registry.getRegistry());
+                """.formatted(registry.getRegistry());
 
         TestUtils.createRegistriesConfFile(homeDir, config);
 
@@ -128,12 +126,10 @@ class RegistryTest {
     void shouldAllowMultipleRegistriesWithDisabledEnforcingMode(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
                 short-name-mode = "disabled"
                 unqualified-search-registries = ["%s", "localhost:5000"]
-                """
-                        .formatted(registry.getRegistry());
+                """.formatted(registry.getRegistry());
 
         TestUtils.createRegistriesConfFile(homeDir, config);
 
@@ -151,12 +147,10 @@ class RegistryTest {
     void shouldEnforceMultipleRegistriesWithPermissiveEnforcingMode(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
                 short-name-mode = "permissive"
                 unqualified-search-registries = ["%s", "localhost:5000"]
-                """
-                        .formatted(registry.getRegistry());
+                """.formatted(registry.getRegistry());
 
         TestUtils.createRegistriesConfFile(homeDir, config);
 
@@ -191,13 +185,11 @@ class RegistryTest {
     void shouldListRepositoriesInsecure(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
@@ -290,13 +282,11 @@ class RegistryTest {
     void shouldMountWithInsecureRegistry(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
@@ -448,13 +438,11 @@ class RegistryTest {
         ExecutorService customExecutor = Executors.newSingleThreadExecutor();
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
@@ -650,13 +638,11 @@ class RegistryTest {
     void shouldPushManifestWithRegistryConfig(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
@@ -690,16 +676,14 @@ class RegistryTest {
     void shouldPushManifestWithAlias(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
 
             [aliases]
             "my-library/my-namespace"="%s/test/bar"
-            """
-                        .formatted(this.unsecureRegistry.getRegistry(), this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry(), this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
@@ -735,8 +719,7 @@ class RegistryTest {
         String config = """
             [aliases]
             "my-library/my-namespace"="localhost/test"
-            """
-                .formatted(this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
@@ -1025,13 +1008,11 @@ class RegistryTest {
         // Use config
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
@@ -1224,16 +1205,14 @@ class RegistryTest {
     void testShouldArtifactWithAlias(@TempDir Path homeDir) throws Exception {
 
         // language=toml
-        String config =
-                """
+        String config = """
             [aliases]
             "the-target" = "%s/test/artifact-target"
 
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(this.unsecureRegistry.getRegistry(), this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry(), this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         // Copy to same registry
@@ -1268,8 +1247,7 @@ class RegistryTest {
             otherRegistryContainer.start();
 
             // language=toml
-            String config =
-                    """
+            String config = """
                 [aliases]
                 "the-source" = "%s/test/artifact-source"
                 "the-target" = "%s/test/artifact-target"
@@ -1281,12 +1259,11 @@ class RegistryTest {
                 [[registry]]
                 location = "%s"
                 insecure = true
-                """
-                            .formatted(
-                                    this.unsecureRegistry.getRegistry(),
-                                    otherRegistryContainer.getRegistry(),
-                                    this.unsecureRegistry.getRegistry(),
-                                    otherRegistryContainer.getRegistry());
+                """.formatted(
+                            this.unsecureRegistry.getRegistry(),
+                            otherRegistryContainer.getRegistry(),
+                            this.unsecureRegistry.getRegistry(),
+                            otherRegistryContainer.getRegistry());
             TestUtils.createRegistriesConfFile(homeDir, config);
 
             // Copy to same registry
@@ -2207,13 +2184,11 @@ class RegistryTest {
     void shouldPushBlobChunkedFromPathViaInsecureRegistryConfig(@TempDir Path homeDir) throws Exception {
 
         // Insecure config
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {
@@ -2246,13 +2221,11 @@ class RegistryTest {
     void shouldPushBlobChunkedFromStreamViaInsecureRegistryConfig(@TempDir Path homeDir) throws Exception {
 
         // Insecure config
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(this.unsecureRegistry.getRegistry());
+            """.formatted(this.unsecureRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, config);
 
         TestUtils.withHome(homeDir, () -> {

--- a/src/test/java/land/oras/RegistryTlsTest.java
+++ b/src/test/java/land/oras/RegistryTlsTest.java
@@ -144,13 +144,11 @@ class RegistryTlsTest {
 
         // Authoritative parent
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 location = "%s"
                 insecure = false
-                """
-                        .formatted(tlsRegistry.getRegistry());
+                """.formatted(tlsRegistry.getRegistry());
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
@@ -176,8 +174,7 @@ class RegistryTlsTest {
         String registriesConf = """
                 [[registry]]
                 location = "%s"
-                """
-                .formatted(tlsRegistry.getRegistry());
+                """.formatted(tlsRegistry.getRegistry());
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 
         Path testFile = blobDir.resolve("downgrade1.txt");
@@ -299,8 +296,7 @@ class RegistryTlsTest {
         // connection to plaintext HTTP. The HTTPS-only container would refuse a plaintext request, so
         // a successful manifest fetch proves the connection stayed on HTTPS.
         // language=toml
-        String registriesConf =
-                """
+        String registriesConf = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -312,8 +308,7 @@ class RegistryTlsTest {
                 prefix = "%s"
                 location = "%s"
                 insecure = true
-                """
-                        .formatted(mirror, mirror, mirror);
+                """.formatted(mirror, mirror, mirror);
 
         TestUtils.createRegistriesConfFile(homeDir, registriesConf);
 

--- a/src/test/java/land/oras/RegistryWireMockTest.java
+++ b/src/test/java/land/oras/RegistryWireMockTest.java
@@ -39,6 +39,7 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -283,8 +284,7 @@ class RegistryWireMockTest {
         // WireMock server. The parent registry is configured with static basic-auth credentials — those
         // credentials must NOT be forwarded to the mirror over plaintext HTTP.
         // language=toml
-        String config =
-                """
+        String config = """
                 [[registry]]
                 prefix = "localhost:59998"
                 location = "localhost:59998"
@@ -292,13 +292,11 @@ class RegistryWireMockTest {
                 [[registry.mirror]]
                 location = "%s"
                 insecure = true
-                """
-                        .formatted(mirrorHost);
+                """.formatted(mirrorHost);
         TestUtils.createRegistriesConfFile(homeDir4, config);
 
         // language=json
-        String manifestJson =
-                """
+        String manifestJson = """
                 {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json",\
                 "config":{"mediaType":"application/vnd.oci.empty.v1+json",\
                 "digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},\
@@ -389,13 +387,11 @@ class RegistryWireMockTest {
         String registryAsString = wmRuntimeInfo.getHttpBaseUrl().replace("http://", "");
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(registryAsString);
+            """.formatted(registryAsString);
         TestUtils.createRegistriesConfFile(homeDir1, config);
 
         // Return data from wiremock
@@ -458,13 +454,11 @@ class RegistryWireMockTest {
         String registryAsString = wmRuntimeInfo.getHttpBaseUrl().replace("http://", "");
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             location = "%s"
             insecure = true
-            """
-                        .formatted(registryAsString);
+            """.formatted(registryAsString);
         TestUtils.createRegistriesConfFile(homeDir2, config);
 
         // Return data from wiremock
@@ -493,13 +487,11 @@ class RegistryWireMockTest {
         String registryAsString = wmRuntimeInfo.getHttpBaseUrl().replace("http://", "");
 
         // language=toml
-        String config =
-                """
+        String config = """
             [[registry]]
             prefix = "%s"
             insecure = true
-            """
-                        .formatted(registryAsString);
+            """.formatted(registryAsString);
         TestUtils.createRegistriesConfFile(homeDir3, config);
 
         // Return data from wiremock
@@ -526,8 +518,7 @@ class RegistryWireMockTest {
     void shouldListTagsWithFileStoreAuth(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
 
         // Auth file for current registry
-        String authFile =
-                """
+        String authFile = """
                 {
                         "auths": {
                                 "localhost:%d": {
@@ -535,8 +526,7 @@ class RegistryWireMockTest {
                                 }
                         }
                 }
-                """
-                        .formatted(wmRuntimeInfo.getHttpPort());
+                """.formatted(wmRuntimeInfo.getHttpPort());
 
         Files.writeString(configDir.resolve("config.json"), authFile, StandardCharsets.UTF_8);
 
@@ -1517,8 +1507,7 @@ class RegistryWireMockTest {
 
         OrasException exStream = assertThrows(
                 OrasException.class,
-                () -> registry.pushBlobChunked(
-                        refStream, new java.io.ByteArrayInputStream(content), content.length, 4L));
+                () -> registry.pushBlobChunked(refStream, new ByteArrayInputStream(content), content.length, 4L));
         assertEquals(
                 "Failed to initiate chunked blob upload: status 500",
                 exStream.getMessage(),
@@ -1579,14 +1568,12 @@ class RegistryWireMockTest {
                         .withHeader(Const.DOCKER_CONTENT_DIGEST_HEADER, digestA)));
 
         // Generic target: accept any manifest push and return an empty index on the follow-up read.
-        String emptyIndex =
-                """
+        String emptyIndex = """
                 {
                   "schemaVersion": 2,
                   "mediaType": "%s",
                   "manifests": []
-                }"""
-                        .formatted(Const.DEFAULT_INDEX_MEDIA_TYPE);
+                }""".formatted(Const.DEFAULT_INDEX_MEDIA_TYPE);
         wireMock.register(WireMock.put(WireMock.urlMatching("/v2/%s/manifests/.*".formatted(dstRepo)))
                 .willReturn(WireMock.created().withHeader(Const.DOCKER_CONTENT_DIGEST_HEADER, digestA)));
         wireMock.register(WireMock.head(WireMock.urlMatching("/v2/%s/manifests/.*".formatted(dstRepo)))
@@ -1634,8 +1621,7 @@ class RegistryWireMockTest {
                       "size": 100
                     }
                   ]
-                }"""
-                .formatted(Const.DEFAULT_INDEX_MEDIA_TYPE, Const.DEFAULT_INDEX_MEDIA_TYPE, childDigest);
+                }""".formatted(Const.DEFAULT_INDEX_MEDIA_TYPE, Const.DEFAULT_INDEX_MEDIA_TYPE, childDigest);
     }
 
     /**
@@ -1743,8 +1729,7 @@ class RegistryWireMockTest {
 
     @Test
     void shouldRejectManifestWhoseContentDoesNotMatchPinnedDigest(WireMockRuntimeInfo wmRuntimeInfo) {
-        String realManifest =
-                """
+        String realManifest = """
                 {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json",\
                 "config":{"mediaType":"application/vnd.oci.empty.v1+json",\
                 "digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},\
@@ -1820,13 +1805,11 @@ class RegistryWireMockTest {
         String referrersPath = "/v2/library/artifact-text/referrers/" + digest;
 
         // Minimal referrers index JSON with one manifest entry per page
-        String page1 =
-                """
+        String page1 = """
                 {"mediaType":"application/vnd.oci.image.index.v1+json","manifests":\
                 [{"mediaType":"application/vnd.oci.image.manifest.v1+json",\
                 "digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":1}]}""";
-        String page2 =
-                """
+        String page2 = """
                 {"mediaType":"application/vnd.oci.image.index.v1+json","manifests":\
                 [{"mediaType":"application/vnd.oci.image.manifest.v1+json",\
                 "digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","size":1}]}""";
@@ -1871,8 +1854,7 @@ class RegistryWireMockTest {
         String fallbackTagPath = "/v2/library/artifact-text/manifests/"
                 + "sha256-44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a";
 
-        String fallbackIndex =
-                """
+        String fallbackIndex = """
                 {"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":\
                 [{"mediaType":"application/vnd.oci.image.manifest.v1+json",\
                 "digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":1,\
@@ -1912,8 +1894,7 @@ class RegistryWireMockTest {
         String fallbackTagPath = "/v2/library/artifact-text/manifests/"
                 + "sha256-44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a";
 
-        String fallbackIndex =
-                """
+        String fallbackIndex = """
                 {"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":\
                 [{"mediaType":"application/vnd.oci.image.manifest.v1+json",\
                 "digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":1,\

--- a/src/test/java/land/oras/auth/AuthStoreTest.java
+++ b/src/test/java/land/oras/auth/AuthStoreTest.java
@@ -58,8 +58,7 @@ class AuthStoreTest {
     private static final String PASSWORD = "password";
 
     // language=json
-    public static final String SAMPLE_DOCKER_CONFIG =
-            """
+    public static final String SAMPLE_DOCKER_CONFIG = """
     {
         "auths": {
             "registry.example.com": {
@@ -82,8 +81,7 @@ class AuthStoreTest {
     """;
 
     // language=json
-    public static final String SAMPLE_PODMAN_CONFIG =
-            """
+    public static final String SAMPLE_PODMAN_CONFIG = """
     {
         "auths": {
             "registry.other.com": {
@@ -293,8 +291,7 @@ class AuthStoreTest {
     }
 
     // language=json
-    public static final String SAMPLE_HIERARCHICAL_CONFIG =
-            """
+    public static final String SAMPLE_HIERARCHICAL_CONFIG = """
     {
         "auths": {
             "my-registry.local/namespace/user/image": {
@@ -412,8 +409,7 @@ class AuthStoreTest {
     @Test
     void testRegistryAuthFileTakesPrecedenceOverDefaults() throws Exception {
         // language=json
-        String customConfig =
-                """
+        String customConfig = """
         {
             "auths": {
                 "custom.registry.com": {
@@ -489,15 +485,13 @@ class AuthStoreTest {
         String auth = java.util.Base64.getEncoder()
                 .encodeToString((user + ":" + password).getBytes(java.nio.charset.StandardCharsets.UTF_8));
         // language=json
-        String config =
-                """
+        String config = """
                 {
                     "auths": {
                         "colon.registry.com": { "auth": "%s" }
                     }
                 }
-                """
-                        .formatted(auth);
+                """.formatted(auth);
         Path configFile = tempDir.resolve("colon-config.json");
         Files.writeString(configFile, config);
 
@@ -516,16 +510,14 @@ class AuthStoreTest {
         String valid = java.util.Base64.getEncoder()
                 .encodeToString("user:password".getBytes(java.nio.charset.StandardCharsets.UTF_8));
         // language=json
-        String config =
-                """
+        String config = """
                 {
                     "auths": {
                         "bad.registry.com": { "auth": "%s" },
                         "good.registry.com": { "auth": "%s" }
                     }
                 }
-                """
-                        .formatted(malformed, valid);
+                """.formatted(malformed, valid);
         Path configFile = tempDir.resolve("malformed-config.json");
         Files.writeString(configFile, config);
 
@@ -542,15 +534,13 @@ class AuthStoreTest {
         String auth =
                 java.util.Base64.getEncoder().encodeToString("user:".getBytes(java.nio.charset.StandardCharsets.UTF_8));
         // language=json
-        String config =
-                """
+        String config = """
                 {
                     "auths": {
                         "empty.registry.com": { "auth": "%s" }
                     }
                 }
-                """
-                        .formatted(auth);
+                """.formatted(auth);
         Path configFile = tempDir.resolve("empty-pass-config.json");
         Files.writeString(configFile, config);
 
@@ -569,15 +559,13 @@ class AuthStoreTest {
         String auth = java.util.Base64.getEncoder()
                 .encodeToString((user + ":" + password).getBytes(java.nio.charset.StandardCharsets.UTF_8));
         // language=json
-        String config =
-                """
+        String config = """
                 {
                     "auths": {
                         "any.registry.com": { "auth": "%s" }
                     }
                 }
-                """
-                        .formatted(auth);
+                """.formatted(auth);
         Path configFile = tempDir.resolve("any-char-config.json");
         Files.writeString(configFile, config);
 
@@ -593,14 +581,12 @@ class AuthStoreTest {
     void shouldRejectCredentialHelperThatEscapesPrefix() throws Exception {
         String maliciousSuffix = "../../../../../../tmp/pwn";
         // language=json
-        String config =
-                """
+        String config = """
                 {
                     "auths": {},
                     "credHelpers": { "evil.registry.com": "%s" }
                 }
-                """
-                        .formatted(maliciousSuffix);
+                """.formatted(maliciousSuffix);
         Path configFile = tempDir.resolve("evil-helper-config.json");
         Files.writeString(configFile, config);
 
@@ -614,8 +600,7 @@ class AuthStoreTest {
     @Test
     void shouldReturnValidCredentialHelperBinary() throws Exception {
         // language=json
-        String config =
-                """
+        String config = """
                 {
                     "auths": {},
                     "credHelpers": { "good.registry.com": "ecr-login" }

--- a/src/test/java/land/oras/auth/RegistriesConfTest.java
+++ b/src/test/java/land/oras/auth/RegistriesConfTest.java
@@ -41,8 +41,7 @@ class RegistriesConfTest {
     private static Path homeDir;
 
     // language=toml
-    public static final String HOME_REGISTRIES_CONF =
-            """
+    public static final String HOME_REGISTRIES_CONF = """
             unqualified-search-registries = ["docker.io"]
 
             [aliases]
@@ -80,10 +79,7 @@ class RegistriesConfTest {
         // language=toml
         TestUtils.createRegistriesConfFile(dropInHomeDir, "unqualified-search-registries = [\"docker.io\"]");
         // language=toml
-        TestUtils.createDropInConfFile(
-                dropInHomeDir,
-                "10-extra.conf",
-                """
+        TestUtils.createDropInConfFile(dropInHomeDir, "10-extra.conf", """
                 [aliases]
                 "myapp"="registry.example.com/myapp"
                 """);
@@ -102,18 +98,12 @@ class RegistriesConfTest {
     void shouldLoadDropInConfFilesInAlphaNumericalOrder(@TempDir Path dropInHomeDir) throws Exception {
         TestUtils.createRegistriesConfFile(dropInHomeDir, "");
         // language=toml
-        TestUtils.createDropInConfFile(
-                dropInHomeDir,
-                "01-first.conf",
-                """
+        TestUtils.createDropInConfFile(dropInHomeDir, "01-first.conf", """
                 [aliases]
                 "foo"="registry.first.com/foo"
                 """);
         // language=toml
-        TestUtils.createDropInConfFile(
-                dropInHomeDir,
-                "02-second.conf",
-                """
+        TestUtils.createDropInConfFile(dropInHomeDir, "02-second.conf", """
                 [aliases]
                 "foo"="registry.second.com/foo"
                 """);

--- a/src/test/java/land/oras/auth/RegistryConfTest.java
+++ b/src/test/java/land/oras/auth/RegistryConfTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -222,8 +223,7 @@ class RegistryConfTest {
     @Test
     void shouldParseMirrorsFromToml() {
         // language=toml
-        String toml =
-                """
+        String toml = """
                 [[registry]]
                 prefix = "docker.io"
                 location = "docker.io"
@@ -362,8 +362,7 @@ class RegistryConfTest {
     @Test
     void shouldParsePullFromMirrorFromToml() {
         // language=toml
-        String toml =
-                """
+        String toml = """
                 [[registry]]
                 prefix = "docker.io"
                 location = "docker.io"
@@ -398,8 +397,7 @@ class RegistryConfTest {
     @Test
     void shouldFilterMirrorsByPullFromMirrorForTagRef() {
         // language=toml
-        String toml =
-                """
+        String toml = """
                 [[registry]]
                 prefix = "docker.io"
                 location = "docker.io"
@@ -430,8 +428,7 @@ class RegistryConfTest {
     @Test
     void shouldFilterMirrorsByPullFromMirrorForDigestRef() {
         // language=toml
-        String toml =
-                """
+        String toml = """
                 [[registry]]
                 prefix = "docker.io"
                 location = "docker.io"
@@ -463,8 +460,7 @@ class RegistryConfTest {
     @Test
     void shouldApplyMirrorByDigestOnly() {
         // language=toml
-        String toml =
-                """
+        String toml = """
                 [[registry]]
                 prefix = "docker.io"
                 location = "docker.io"
@@ -496,8 +492,7 @@ class RegistryConfTest {
     @Test
     void shouldReturnAllMirrorsWhenNoFilterConfigured() {
         // language=toml
-        String toml =
-                """
+        String toml = """
                 [[registry]]
                 prefix = "docker.io"
                 location = "docker.io"
@@ -520,7 +515,7 @@ class RegistryConfTest {
             temp.toFile().deleteOnExit();
             Files.writeString(temp, content);
             return temp;
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/land/oras/policy/ContainersPolicyTest.java
+++ b/src/test/java/land/oras/policy/ContainersPolicyTest.java
@@ -276,12 +276,9 @@ class ContainersPolicyTest {
         KeyPair kp = SigstoreTestSupport.generateKeyPair();
         Path path = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                path,
-                """
+        Files.writeString(path, """
                 {"default": [{"type": "sigstoreSigned", "keyData": "%s"}]}
-                """
-                        .formatted(SigstoreTestSupport.keyData(kp.getPublic())));
+                """.formatted(SigstoreTestSupport.keyData(kp.getPublic())));
         ContainersPolicy policy = ContainersPolicy.newPolicy(path);
 
         assertDoesNotThrow(() -> policy.verify(context(
@@ -358,9 +355,7 @@ class ContainersPolicyTest {
 
         Path path = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                path,
-                """
+        Files.writeString(path, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -372,10 +367,8 @@ class ContainersPolicyTest {
                     }
                   }
                 }
-                """
-                        .formatted(
-                                keyFile1.toString().replace("\\", "\\\\"),
-                                keyFile2.toString().replace("\\", "\\\\")));
+                """.formatted(
+                keyFile1.toString().replace("\\", "\\\\"), keyFile2.toString().replace("\\", "\\\\")));
         ContainersPolicy policy = ContainersPolicy.newPolicy(path);
 
         // Accepted when signed by kp1
@@ -407,9 +400,7 @@ class ContainersPolicyTest {
 
         Path path = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                path,
-                """
+        Files.writeString(path, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -421,10 +412,8 @@ class ContainersPolicyTest {
                     }
                   }
                 }
-                """
-                        .formatted(
-                                SigstoreTestSupport.keyData(kp1.getPublic()),
-                                SigstoreTestSupport.keyData(kp2.getPublic())));
+                """.formatted(
+                        SigstoreTestSupport.keyData(kp1.getPublic()), SigstoreTestSupport.keyData(kp2.getPublic())));
         ContainersPolicy policy = ContainersPolicy.newPolicy(path);
 
         // Accepted when signed by kp1
@@ -453,9 +442,7 @@ class ContainersPolicyTest {
     void sigstoreSignedKeyPathsDeserializesCorrectly(@TempDir Path dir) throws IOException {
         Path path = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                path,
-                """
+        Files.writeString(path, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -483,9 +470,7 @@ class ContainersPolicyTest {
     void signedByGpgIsDeniedBecauseNotImplemented(@TempDir Path dir) throws IOException {
         Path path = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                path,
-                """
+        Files.writeString(path, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -508,9 +493,7 @@ class ContainersPolicyTest {
         KeyPair kp = SigstoreTestSupport.generateKeyPair();
         Path path = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                path,
-                """
+        Files.writeString(path, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -521,8 +504,7 @@ class ContainersPolicyTest {
                     }
                   }
                 }
-                """
-                        .formatted(SigstoreTestSupport.keyData(kp.getPublic())));
+                """.formatted(SigstoreTestSupport.keyData(kp.getPublic())));
         ContainersPolicy policy = ContainersPolicy.newPolicy(path);
 
         // Open scope: accepted without signatures.
@@ -563,9 +545,7 @@ class ContainersPolicyTest {
             throws IOException {
         Path path = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                path,
-                """
+        Files.writeString(path, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -574,8 +554,7 @@ class ContainersPolicyTest {
                     }
                   }
                 }
-                """
-                        .formatted(scopeKey, keyField, keyValue));
+                """.formatted(scopeKey, keyField, keyValue));
         return ContainersPolicy.newPolicy(path);
     }
 

--- a/src/test/java/land/oras/policy/SigstoreTestSupport.java
+++ b/src/test/java/land/oras/policy/SigstoreTestSupport.java
@@ -72,8 +72,7 @@ final class SigstoreTestSupport {
                 -----BEGIN PUBLIC KEY-----
                 %s
                 -----END PUBLIC KEY-----
-                """
-                .formatted(b64);
+                """.formatted(b64);
     }
 
     /**
@@ -122,8 +121,7 @@ final class SigstoreTestSupport {
                   "subject": [{"digest": {"sha256": "%s"}, "annotations": {}}],
                   "predicateType": "https://sigstore.dev/cosign/sign/v1",
                   "predicate": {}
-                }"""
-                .formatted(imageHex);
+                }""".formatted(imageHex);
     }
 
     private static String bundleJson(byte[] payload, byte[] signature) {
@@ -137,8 +135,7 @@ final class SigstoreTestSupport {
                     "payloadType": "%s",
                     "signatures": [{"sig": "%s"}]
                   }
-                }"""
-                .formatted(
+                }""".formatted(
                         Const.SIGSTORE_BUNDLE_MEDIA_TYPE,
                         b64.encodeToString(payload),
                         Const.IN_TOTO_PAYLOAD_TYPE,

--- a/src/test/java/land/oras/policy/SigstoreVerifierTest.java
+++ b/src/test/java/land/oras/policy/SigstoreVerifierTest.java
@@ -142,13 +142,13 @@ class SigstoreVerifierTest {
         // keyPaths list
         PolicyRequirement.SigstoreSigned fromPaths = new PolicyRequirement.SigstoreSigned(
                 null, null, List.of(keyFile1.toString(), keyFile2.toString()), null);
-        List<java.security.PublicKey> loadedFromPaths = SigstoreVerifier.loadKeys(fromPaths);
+        List<PublicKey> loadedFromPaths = SigstoreVerifier.loadKeys(fromPaths);
         assertEquals(2, loadedFromPaths.size());
 
         // keyDatas list
         PolicyRequirement.SigstoreSigned fromDatas =
                 new PolicyRequirement.SigstoreSigned(null, null, null, List.of(keyData1, keyData2));
-        List<java.security.PublicKey> loadedFromDatas = SigstoreVerifier.loadKeys(fromDatas);
+        List<PublicKey> loadedFromDatas = SigstoreVerifier.loadKeys(fromDatas);
         assertEquals(2, loadedFromDatas.size());
     }
 
@@ -180,9 +180,7 @@ class SigstoreVerifierTest {
 
         Path policyPath = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                policyPath,
-                """
+        Files.writeString(policyPath, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -193,8 +191,7 @@ class SigstoreVerifierTest {
                     }
                   }
                 }
-                """
-                        .formatted(keyFile.toString().replace("\\", "\\\\")));
+                """.formatted(keyFile.toString().replace("\\", "\\\\")));
 
         ContainersPolicy policy = ContainersPolicy.newPolicy(policyPath);
 
@@ -224,9 +221,7 @@ class SigstoreVerifierTest {
 
         Path policyPath = dir.resolve("policy.json");
         // language=json
-        Files.writeString(
-                policyPath,
-                """
+        Files.writeString(policyPath, """
                 {
                   "default": [{"type": "reject"}],
                   "transports": {
@@ -277,8 +272,7 @@ class SigstoreVerifierTest {
                   "subject": [{"digest": {"sha256": "%s"}, "annotations": {}}],
                   "predicateType": "https://sigstore.dev/cosign/sign/v1",
                   "predicate": {}
-                }"""
-                .formatted(imageHex);
+                }""".formatted(imageHex);
     }
 
     private static String bundleJson(byte[] payload, byte[] signature) {
@@ -292,8 +286,7 @@ class SigstoreVerifierTest {
                     "payloadType": "%s",
                     "signatures": [{"sig": "%s"}]
                   }
-                }"""
-                .formatted(
+                }""".formatted(
                         Const.SIGSTORE_BUNDLE_MEDIA_TYPE,
                         b64.encodeToString(payload),
                         Const.IN_TOTO_PAYLOAD_TYPE,
@@ -307,7 +300,6 @@ class SigstoreVerifierTest {
                 -----BEGIN PUBLIC KEY-----
                 %s
                 -----END PUBLIC KEY-----
-                """
-                .formatted(b64);
+                """.formatted(b64);
     }
 }

--- a/src/test/java/land/oras/utils/ArchiveUtilsTest.java
+++ b/src/test/java/land/oras/utils/ArchiveUtilsTest.java
@@ -30,6 +30,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import land.oras.LocalPath;
 import land.oras.exception.OrasException;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -410,8 +412,8 @@ class ArchiveUtilsTest {
         byte[] secondContent = "second-overwritten".getBytes();
 
         Path zip1 = tmp.resolve("first.zip");
-        try (java.util.zip.ZipOutputStream zout = new java.util.zip.ZipOutputStream(Files.newOutputStream(zip1))) {
-            zout.putNextEntry(new java.util.zip.ZipEntry("file.txt"));
+        try (ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(zip1))) {
+            zout.putNextEntry(new ZipEntry("file.txt"));
             zout.write(firstContent);
             zout.closeEntry();
         }
@@ -419,8 +421,8 @@ class ArchiveUtilsTest {
         assertEquals("first", Files.readString(target.resolve("file.txt")));
 
         Path zip2 = tmp.resolve("second.zip");
-        try (java.util.zip.ZipOutputStream zout = new java.util.zip.ZipOutputStream(Files.newOutputStream(zip2))) {
-            zout.putNextEntry(new java.util.zip.ZipEntry("file.txt"));
+        try (ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(zip2))) {
+            zout.putNextEntry(new ZipEntry("file.txt"));
             zout.write(secondContent);
             zout.closeEntry();
         }

--- a/src/test/java/land/oras/utils/YamlUtilsTest.java
+++ b/src/test/java/land/oras/utils/YamlUtilsTest.java
@@ -53,8 +53,7 @@ class YamlUtilsTest {
     @Test
     @SuppressWarnings("unchecked")
     void shouldParseYaml() {
-        String yamlMap =
-                """
+        String yamlMap = """
                 ---
                 key1: "value1"
                 key2: "value2"
@@ -69,8 +68,7 @@ class YamlUtilsTest {
     @Test
     @SuppressWarnings("unchecked")
     void shouldParseYamlFile() throws IOException {
-        String yamlMap =
-                """
+        String yamlMap = """
                 ---
                 key1: "value1"
                 key2: "value2"

--- a/src/test/java/land/oras/utils/ZotContainer.java
+++ b/src/test/java/land/oras/utils/ZotContainer.java
@@ -44,8 +44,7 @@ public class ZotContainer extends ZotBaseContainer<ZotContainer> {
             copyFileToContainer(authFile, "/etc/zot/auth.htpasswd");
 
             // language=JSON
-            String configJson =
-                    """
+            String configJson = """
                     {
                       "storage": { "rootDirectory": "/var/lib/registry" },
                       "http": {
@@ -59,8 +58,7 @@ public class ZotContainer extends ZotBaseContainer<ZotContainer> {
                         "search": { "enable": true }
                       }
                     }
-                    """
-                            .formatted(ZOT_PORT);
+                    """.formatted(ZOT_PORT);
             writeConfig(configJson);
 
         } catch (Exception e) {

--- a/src/test/java/land/oras/utils/ZotTlsContainer.java
+++ b/src/test/java/land/oras/utils/ZotTlsContainer.java
@@ -66,8 +66,7 @@ public class ZotTlsContainer extends ZotBaseContainer<ZotTlsContainer> {
             copyFileToContainer(serverKeyPath, "/etc/zot/server-key.pem");
 
             // language=JSON
-            String configJson =
-                    """
+            String configJson = """
                     {
                       "storage": { "rootDirectory": "/var/lib/registry" },
                       "http": {
@@ -82,8 +81,7 @@ public class ZotTlsContainer extends ZotBaseContainer<ZotTlsContainer> {
                         "search": { "enable": true }
                       }
                     }
-                    """
-                            .formatted(ZOT_PORT);
+                    """.formatted(ZOT_PORT);
             writeConfig(configJson);
 
         } catch (Exception e) {

--- a/src/test/java/land/oras/utils/ZotUnsecureContainer.java
+++ b/src/test/java/land/oras/utils/ZotUnsecureContainer.java
@@ -33,8 +33,7 @@ public class ZotUnsecureContainer extends ZotBaseContainer<ZotUnsecureContainer>
         setWaitStrategy(Wait.forHttp("/v2/_catalog").forPort(ZOT_PORT).forStatusCode(200));
 
         // language=JSON
-        String configJson =
-                """
+        String configJson = """
                 {
                   "storage": { "rootDirectory": "/var/lib/registry" },
                   "http": {
@@ -45,8 +44,7 @@ public class ZotUnsecureContainer extends ZotBaseContainer<ZotUnsecureContainer>
                     "search": { "enable": true }
                   }
                 }
-                """
-                        .formatted(ZOT_PORT);
+                """.formatted(ZOT_PORT);
         writeConfig(configJson);
     }
 }


### PR DESCRIPTION
### Description

Shorten FQDN types and enforce it with spotless 

### Testing done

None

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
