### PR TITLE
The policy evalation is called too often and print warning on each content evaluation

### DIFF
--- a/src/main/java/land/oras/policy/PolicyRequirement.java
+++ b/src/main/java/land/oras/policy/PolicyRequirement.java
@@ -114,7 +114,7 @@ public abstract sealed class PolicyRequirement
 
         @Override
         boolean verify(PolicyContext context) {
-            LOG.warn(
+            LOG.info(
                     "Policy requirement '{}' for transport {} and scope {} (no signature verification)",
                     getType(),
                     context.getTransport(),


### PR DESCRIPTION
### Description

The policy evalation is called too often and print warning on each content evaluation

### Testing done

None

### Submitter checklist
- [x] I have read and understood the [CONTRIBUTING](https://github.com/oras-project/oras-java/blob/main/CONTRIBUTING.md) guide
- [x] I have run `mvn license:update-file-header`, `mvn spotless:apply`, `pre-commit run -a`, `mvn clean install` before opening the PR
